### PR TITLE
feat: Kraken exchange integration with broker abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,32 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 # Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:
 TWILIO_WHATSAPP_FROM=whatsapp:+17343367101
 
-# Robinhood crypto live-trading defaults (safe by default).
+# ── Broker selection: paper | robinhood | kraken ──
+BROKER_TYPE=paper
+
+# ── Robinhood crypto (legacy) ──
 RH_CRYPTO_API_KEY=
 RH_CRYPTO_PRIVATE_KEY_SEED=
 RH_CRYPTO_BASE_URL=https://trading.robinhood.com
 RH_LIVE_TRADING=false
 RH_LIVE_CONFIRM=
+
+# ── Kraken Spot (new) ──
+KRAKEN_API_KEY=
+KRAKEN_API_SECRET=
+KRAKEN_BASE_URL=https://api.kraken.com
+KRAKEN_WS_URL=wss://ws.kraken.com/v2
+KRAKEN_WS_AUTH_URL=wss://ws-auth.kraken.com/v2
+KRAKEN_LIVE_TRADING=false
+KRAKEN_LIVE_CONFIRM=
+# Rate limiting (Intermediate tier: 20 calls, 0.5/s decay)
+KRAKEN_RATE_LIMIT_CALLS=20
+KRAKEN_RATE_LIMIT_DECAY=0.5
+
+# ── Market data source: polling | kraken_ws ──
+MARKET_DATA_SOURCE=polling
+
+# ── Common ──
 ADMIN_USER_ID=292890243852664855
 MAX_NOTIONAL_PER_TRADE=10
 MAX_DAILY_NOTIONAL=50
@@ -17,6 +37,8 @@ MAX_OPEN_POSITIONS=3
 STOP_TRADING_ON_DEGRADED=true
 RECONCILE_INTERVAL_SECONDS=60
 ORDER_POLL_INTERVAL_SECONDS=5
+STALE_DATA_THRESHOLD_S=5
+REPOSITIONER_TIMEOUT_S=300
 
 # ── Edge Factory (Regime-Adaptive Crypto Trading Bot) ────────
 EDGE_FACTORY_MODE=disabled

--- a/migrations/20260214_kraken_market_data.sql
+++ b/migrations/20260214_kraken_market_data.sql
@@ -1,0 +1,91 @@
+-- Kraken market data tables: catalog, focus snapshots, scout snapshots.
+-- Phase 1 of Kraken migration.
+
+-- ── Market catalog (all tradeable pairs with metadata) ──
+
+CREATE TABLE IF NOT EXISTS public.market_catalog (
+  symbol TEXT PRIMARY KEY,              -- "BTC/USD"
+  base_asset TEXT NOT NULL,
+  quote_asset TEXT NOT NULL,
+  lot_decimals INT NOT NULL DEFAULT 8,
+  pair_decimals INT NOT NULL DEFAULT 1,
+  lot_min NUMERIC NOT NULL DEFAULT 0,
+  cost_min NUMERIC NOT NULL DEFAULT 0,
+  tick_size NUMERIC,
+  status TEXT NOT NULL DEFAULT 'online',
+  ordermin NUMERIC,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Focus snapshots (high-priority symbols, updated sub-second) ──
+
+CREATE TABLE IF NOT EXISTS public.market_snapshot_focus (
+  symbol TEXT PRIMARY KEY,
+  bid NUMERIC,
+  ask NUMERIC,
+  mid NUMERIC,
+  last_price NUMERIC,
+  volume_24h NUMERIC,
+  change_pct_24h NUMERIC,
+  spread_bps NUMERIC,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Scout snapshots (broad universe, updated every ~10s) ──
+
+CREATE TABLE IF NOT EXISTS public.market_snapshot_scout (
+  symbol TEXT PRIMARY KEY,
+  mid NUMERIC,
+  volume_24h NUMERIC,
+  change_pct_24h NUMERIC,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Relax source CHECK constraints to support Kraken ──
+
+ALTER TABLE public.crypto_cash_snapshots
+  DROP CONSTRAINT IF EXISTS crypto_cash_snapshots_source_check;
+ALTER TABLE public.crypto_cash_snapshots
+  ADD CONSTRAINT crypto_cash_snapshots_source_check
+  CHECK (source IN ('robinhood', 'kraken'));
+
+ALTER TABLE public.crypto_holdings_snapshots
+  DROP CONSTRAINT IF EXISTS crypto_holdings_snapshots_source_check;
+ALTER TABLE public.crypto_holdings_snapshots
+  ADD CONSTRAINT crypto_holdings_snapshots_source_check
+  CHECK (source IN ('robinhood', 'kraken'));
+
+-- ── RLS: anon can read, service_role has full access ──
+
+ALTER TABLE public.market_catalog ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.market_snapshot_focus ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.market_snapshot_scout ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY market_catalog_anon_read ON public.market_catalog
+  FOR SELECT TO anon USING (true);
+CREATE POLICY market_catalog_service_all ON public.market_catalog
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY market_snapshot_focus_anon_read ON public.market_snapshot_focus
+  FOR SELECT TO anon USING (true);
+CREATE POLICY market_snapshot_focus_service_all ON public.market_snapshot_focus
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY market_snapshot_scout_anon_read ON public.market_snapshot_scout
+  FOR SELECT TO anon USING (true);
+CREATE POLICY market_snapshot_scout_service_all ON public.market_snapshot_scout
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ── Grants ──
+
+GRANT SELECT ON public.market_catalog TO anon;
+GRANT ALL ON public.market_catalog TO service_role;
+
+GRANT SELECT ON public.market_snapshot_focus TO anon;
+GRANT ALL ON public.market_snapshot_focus TO service_role;
+
+GRANT SELECT ON public.market_snapshot_scout TO anon;
+GRANT ALL ON public.market_snapshot_scout TO service_role;
+
+-- Reload PostgREST schema cache
+NOTIFY pgrst, 'reload schema';

--- a/migrations/20260215_kraken_order_engine.sql
+++ b/migrations/20260215_kraken_order_engine.sql
@@ -1,0 +1,114 @@
+-- Kraken order engine: intents, positions, trade locks.
+-- Phase 2 of Kraken migration.
+
+-- ── Order intents (every order starts as an intent before API call) ──
+
+CREATE TABLE IF NOT EXISTS public.order_intents (
+  intent_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  symbol TEXT NOT NULL,
+  side TEXT NOT NULL CHECK (side IN ('buy', 'sell')),
+  qty NUMERIC NOT NULL,
+  limit_price NUMERIC,
+  order_type TEXT NOT NULL DEFAULT 'limit',
+  strategy TEXT,
+  reason TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'submitted', 'filled', 'partially_filled', 'cancelled', 'rejected', 'expired')),
+  client_order_id TEXT UNIQUE,
+  submitted_at TIMESTAMPTZ,
+  resolved_at TIMESTAMPTZ,
+  mode TEXT NOT NULL DEFAULT 'paper',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Positions (tracked by avg cost method) ──
+
+CREATE TABLE IF NOT EXISTS public.positions (
+  symbol TEXT NOT NULL,
+  qty NUMERIC NOT NULL DEFAULT 0,
+  avg_cost NUMERIC NOT NULL DEFAULT 0,
+  mode TEXT NOT NULL DEFAULT 'paper',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (symbol, mode)
+);
+
+-- ── Trade locks (prevent concurrent orders on same symbol) ──
+
+CREATE TABLE IF NOT EXISTS public.trade_locks (
+  symbol TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  locked_by TEXT NOT NULL,
+  locked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (symbol, mode)
+);
+
+-- ── Add intent_id FK to existing crypto_orders ──
+
+ALTER TABLE public.crypto_orders
+  ADD COLUMN IF NOT EXISTS intent_id UUID REFERENCES public.order_intents(intent_id);
+
+-- ── Add fee_currency to existing fills ──
+
+ALTER TABLE public.crypto_fills
+  ADD COLUMN IF NOT EXISTS fee_currency TEXT DEFAULT 'USD';
+
+-- ── Rename reconciliation columns for broker-agnostic naming ──
+-- (only rename if old columns exist; skip if already renamed)
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'crypto_reconciliation_events' AND column_name = 'rh_cash') THEN
+    ALTER TABLE public.crypto_reconciliation_events RENAME COLUMN rh_cash TO broker_cash;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'crypto_reconciliation_events' AND column_name = 'rh_holdings') THEN
+    ALTER TABLE public.crypto_reconciliation_events RENAME COLUMN rh_holdings TO broker_holdings;
+  END IF;
+END $$;
+
+-- ── Indexes ──
+
+CREATE INDEX IF NOT EXISTS order_intents_mode_status_idx
+  ON public.order_intents(mode, status);
+
+CREATE INDEX IF NOT EXISTS order_intents_client_order_id_idx
+  ON public.order_intents(client_order_id);
+
+CREATE INDEX IF NOT EXISTS positions_mode_idx
+  ON public.positions(mode);
+
+CREATE INDEX IF NOT EXISTS trade_locks_expires_idx
+  ON public.trade_locks(expires_at);
+
+-- ── RLS ──
+
+ALTER TABLE public.order_intents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.positions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trade_locks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY order_intents_anon_read ON public.order_intents
+  FOR SELECT TO anon USING (true);
+CREATE POLICY order_intents_service_all ON public.order_intents
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY positions_anon_read ON public.positions
+  FOR SELECT TO anon USING (true);
+CREATE POLICY positions_service_all ON public.positions
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY trade_locks_service_all ON public.trade_locks
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ── Grants ──
+
+GRANT SELECT ON public.order_intents TO anon;
+GRANT ALL ON public.order_intents TO service_role;
+
+GRANT SELECT ON public.positions TO anon;
+GRANT ALL ON public.positions TO service_role;
+
+GRANT ALL ON public.trade_locks TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/migrations/20260216_kraken_accounting.sql
+++ b/migrations/20260216_kraken_accounting.sql
@@ -1,0 +1,45 @@
+-- Kraken accounting: fee ledger, enhanced PnL.
+-- Phase 3 of Kraken migration.
+
+-- ── Fee ledger (every fill records its fee separately for audit) ──
+
+CREATE TABLE IF NOT EXISTS public.fee_ledger (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  fill_id TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  fee NUMERIC NOT NULL,
+  fee_currency TEXT NOT NULL DEFAULT 'USD',
+  fee_usd NUMERIC NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'paper',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── Enhance pnl_daily with new columns ──
+
+ALTER TABLE public.pnl_daily ADD COLUMN IF NOT EXISTS gross_equity NUMERIC DEFAULT 0;
+ALTER TABLE public.pnl_daily ADD COLUMN IF NOT EXISTS fees_usd NUMERIC DEFAULT 0;
+ALTER TABLE public.pnl_daily ADD COLUMN IF NOT EXISTS positions_count INT DEFAULT 0;
+
+-- ── Indexes ──
+
+CREATE INDEX IF NOT EXISTS fee_ledger_mode_created_idx
+  ON public.fee_ledger(mode, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS fee_ledger_fill_id_idx
+  ON public.fee_ledger(fill_id);
+
+-- ── RLS ──
+
+ALTER TABLE public.fee_ledger ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fee_ledger_anon_read ON public.fee_ledger
+  FOR SELECT TO anon USING (true);
+CREATE POLICY fee_ledger_service_all ON public.fee_ledger
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ── Grants ──
+
+GRANT SELECT ON public.fee_ledger TO anon;
+GRANT ALL ON public.fee_ledger TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/services/crypto_trader/broker.py
+++ b/services/crypto_trader/broker.py
@@ -1,21 +1,53 @@
 from __future__ import annotations
 
-import asyncio
+import uuid
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 from integrations.robinhood_crypto_client import RobinhoodCryptoClient
-from .config import CryptoTraderConfig
+
 
 class Broker(ABC):
+    """Exchange-agnostic broker interface.
+
+    Core methods (required):
+      - get_cash, get_positions, place_order
+
+    Extended methods (optional, with default no-op implementations
+    so existing subclasses don't break):
+      - cancel_order, get_open_orders, get_fills, get_balances
+    """
+
     @abstractmethod
     async def get_cash(self) -> float: ...
-    
+
     @abstractmethod
     async def get_positions(self) -> Dict[str, float]: ...
-    
+
     @abstractmethod
-    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]: ...
+    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float,
+                          *, order_type: str = "limit", client_order_id: str | None = None) -> Dict[str, Any]: ...
+
+    # ── Extended interface (added for Kraken; backward-compatible defaults) ──
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open order. Returns True if cancelled."""
+        raise NotImplementedError(f"{type(self).__name__} does not support cancel_order")
+
+    async def get_open_orders(self) -> list[Dict[str, Any]]:
+        """List currently open orders."""
+        return []
+
+    async def get_fills(self, order_id: str) -> list[Dict[str, Any]]:
+        """Get fills for a specific order."""
+        return []
+
+    async def get_balances(self) -> Dict[str, float]:
+        """Get all asset balances (multi-asset). Default: {"USD": get_cash()}."""
+        cash = await self.get_cash()
+        return {"USD": cash}
+
 
 class RobinhoodBroker(Broker):
     def __init__(self, client: RobinhoodCryptoClient):
@@ -29,15 +61,14 @@ class RobinhoodBroker(Broker):
         holdings_resp = await self.client.get_holdings()
         items = holdings_resp.get("results", [])
         return {
-            item["symbol"]: float(item.get("quantity", 0.0)) 
-            for item in items 
+            item["symbol"]: float(item.get("quantity", 0.0))
+            for item in items
             if float(item.get("quantity", 0.0)) > 0
         }
 
-    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]:
-        # Using Limit Orders by default as requested
-        import uuid
-        client_oid = f"zoe-prod-{uuid.uuid4()}"
+    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float,
+                          *, order_type: str = "limit", client_order_id: str | None = None) -> Dict[str, Any]:
+        client_oid = client_order_id or f"zoe-prod-{uuid.uuid4()}"
         return await self.client.place_order(
             symbol=symbol,
             side=side,
@@ -47,75 +78,99 @@ class RobinhoodBroker(Broker):
             limit_price=limit_price
         )
 
+
 class PaperBroker(Broker):
-    """Simulates trades with pessimistic fills (Ask for Buy, Bid for Sell)."""
-    def __init__(self, market_data_provider: Any, repo: Any):
+    """Simulates trades with Kraken-like fees.
+
+    Fee model (matching Kraken base tier):
+      - Market orders (taker): 0.40%
+      - Limit orders (maker):  0.25%
+    Slippage: 0.05% adverse (buy at ask + slippage, sell at bid - slippage).
+    """
+
+    TAKER_FEE_PCT = 0.0040   # 0.40%
+    MAKER_FEE_PCT = 0.0025   # 0.25%
+    SLIPPAGE_PCT = 0.0005    # 0.05%
+
+    def __init__(self, market_data_provider: Any, repo: Any, starting_cash: float = 2000.0):
         self.mdp = market_data_provider
         self.repo = repo
-        self._cash = 2000.0 # Start with $2k paper
+        self._cash = starting_cash
         self._positions: Dict[str, float] = {}
 
     async def get_cash(self) -> float:
-        # In a real paper broker, we'd persist this to DB.
-        # For now, reading from repo or memory.
         return self._cash
 
     async def get_positions(self) -> Dict[str, float]:
-        return self._positions
+        return dict(self._positions)
 
-    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]:
-        # Validate price against current market to simulate fill probability
+    async def get_balances(self) -> Dict[str, float]:
+        balances: Dict[str, float] = {"USD": self._cash}
+        for sym, qty in self._positions.items():
+            if qty > 0:
+                balances[sym] = qty
+        return balances
+
+    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float,
+                          *, order_type: str = "limit", client_order_id: str | None = None) -> Dict[str, Any]:
         current_price = await self.mdp.get_current_price(symbol)
-        
-        # Slippage/Pessimism
-        # If BUY: limit_price must be >= current_price * 1.001 (0.1% buffer) to fill immediately
-        # If SELL: limit_price must be <= current_price * 0.999
-        
+
+        # Determine fee rate based on order type
+        fee_pct = self.TAKER_FEE_PCT if order_type == "market" else self.MAKER_FEE_PCT
+
+        # Fill simulation
         filled = False
         avg_price = 0.0
-        
+
         if side == "buy":
-            if limit_price >= current_price:
+            if order_type == "market" or limit_price >= current_price:
                 filled = True
-                avg_price = current_price * 1.001 # Slippage
-        else: # sell
-            if limit_price <= current_price:
+                avg_price = current_price * (1 + self.SLIPPAGE_PCT)
+        else:  # sell
+            if order_type == "market" or limit_price <= current_price:
                 filled = True
-                avg_price = current_price * 0.999 # Slippage
-        
-        import uuid
-        order_id = str(uuid.uuid4())
-        
+                avg_price = current_price * (1 - self.SLIPPAGE_PCT)
+
+        order_id = client_order_id or str(uuid.uuid4())
+        fee = round(qty * avg_price * fee_pct, 8) if filled else 0.0
+
         status = "filled" if filled else "open"
-        order = {
+        order: Dict[str, Any] = {
             "id": order_id,
+            "client_order_id": order_id,
             "symbol": symbol,
             "side": side,
             "qty": qty,
-            "type": "limit",
+            "type": order_type,
             "limit_price": limit_price,
             "status": status,
             "filled_qty": qty if filled else 0,
             "avg_price": avg_price,
+            "fee": fee,
+            "fee_currency": "USD",
         }
-        
+
         if filled:
-            # Update local state
             cost = qty * avg_price
             if side == "buy":
-                if self._cash >= cost:
-                    self._cash -= cost
+                total_cost = cost + fee
+                if self._cash >= total_cost:
+                    self._cash -= total_cost
                     self._positions[symbol] = self._positions.get(symbol, 0.0) + qty
                 else:
                     order["status"] = "rejected"
                     order["reject_reason"] = "Insufficient funds"
+                    return order
             else:
                 if self._positions.get(symbol, 0.0) >= qty:
-                    self._cash += cost
+                    self._cash += cost - fee
                     self._positions[symbol] -= qty
+                    if self._positions[symbol] <= 0:
+                        del self._positions[symbol]
                 else:
                     order["status"] = "rejected"
                     order["reject_reason"] = "Insufficient position"
+                    return order
 
             # Log to DB
             await self.repo.insert_order(order)
@@ -126,7 +181,13 @@ class PaperBroker(Broker):
                 "side": side,
                 "qty": qty,
                 "price": avg_price,
+                "fee": fee,
+                "fee_currency": "USD",
                 "executed_at": datetime.now(timezone.utc).isoformat()
             })
-            
+
         return order
+
+    async def cancel_order(self, order_id: str) -> bool:
+        # Paper broker: always succeeds (orders are instant-fill or nothing)
+        return True

--- a/services/crypto_trader/broker_factory.py
+++ b/services/crypto_trader/broker_factory.py
@@ -1,0 +1,72 @@
+"""Broker factory — creates the correct Broker implementation based on config.
+
+Usage:
+    from .broker_factory import create_broker
+    broker = await create_broker(config, repo=repo, market_data_provider=mdp)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .broker import Broker, PaperBroker, RobinhoodBroker
+
+
+async def create_broker(
+    config: Any,
+    *,
+    repo: Any = None,
+    market_data_provider: Any = None,
+) -> Broker:
+    """Create a Broker instance based on BROKER_TYPE config.
+
+    Args:
+        config: CryptoTraderConfig (must have .broker_type attribute)
+        repo: Supabase repository (needed for PaperBroker)
+        market_data_provider: Price data source (needed for PaperBroker)
+
+    Returns:
+        Configured Broker instance.
+
+    Supported broker_type values:
+        "paper"     — PaperBroker with simulated Kraken fees
+        "robinhood" — RobinhoodBroker (legacy, requires RH client)
+        "kraken"    — KrakenBroker (requires Kraken API key/secret)
+    """
+    broker_type = getattr(config, "broker_type", "paper").lower()
+
+    if broker_type == "paper":
+        if market_data_provider is None or repo is None:
+            raise ValueError("PaperBroker requires market_data_provider and repo")
+        starting_cash = getattr(config, "starting_equity", 2000.0)
+        return PaperBroker(market_data_provider, repo, starting_cash=starting_cash)
+
+    if broker_type == "robinhood":
+        from integrations.robinhood_crypto_client import RobinhoodCryptoClient
+        client = RobinhoodCryptoClient(
+            api_key=config.rh_crypto_api_key,
+            private_key_seed=config.rh_crypto_private_key_seed,
+            base_url=getattr(config, "rh_crypto_base_url", "https://trading.robinhood.com"),
+        )
+        return RobinhoodBroker(client)
+
+    if broker_type == "kraken":
+        from .kraken_client import KrakenRestClient
+        from .kraken_broker import KrakenBroker
+
+        api_key = getattr(config, "kraken_api_key", "")
+        api_secret = getattr(config, "kraken_api_secret", "")
+        if not api_key or not api_secret:
+            raise ValueError("KRAKEN_API_KEY and KRAKEN_API_SECRET are required for broker_type=kraken")
+
+        base_url = getattr(config, "kraken_base_url", None)
+        client = KrakenRestClient(
+            api_key=api_key,
+            api_secret=api_secret,
+            base_url=base_url,
+        )
+        broker = KrakenBroker(client)
+        await broker.ensure_pair_cache()
+        return broker
+
+    raise ValueError(f"Unknown broker_type: {broker_type!r} (expected: paper, robinhood, kraken)")

--- a/services/crypto_trader/circuit_breaker.py
+++ b/services/crypto_trader/circuit_breaker.py
@@ -1,0 +1,119 @@
+"""Stale-data circuit breaker for the trading pipeline.
+
+If market data for any focus symbol is older than a configurable threshold
+(default: 5 seconds), the circuit breaker trips and blocks new order entries.
+It automatically resets when fresh data arrives.
+
+States:
+  CLOSED  — data is fresh, trading allowed
+  OPEN    — data is stale, trading blocked
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"  # healthy — trading allowed
+    OPEN = "open"      # tripped — trading blocked
+
+
+class CircuitBreaker:
+    """Prevents order entry when market data is stale."""
+
+    def __init__(self, threshold_s: float = 5.0):
+        """
+        Args:
+            threshold_s: Max age (seconds) of focus data before tripping.
+        """
+        self.threshold_s = threshold_s
+        self._state = CircuitState.CLOSED
+        self._tripped_at: float = 0.0
+        self._stale_symbols: list[str] = []
+
+        # Stats
+        self.trip_count: int = 0
+        self.last_trip_duration_s: float = 0.0
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    @property
+    def is_open(self) -> bool:
+        """True if circuit is tripped (trading blocked)."""
+        return self._state == CircuitState.OPEN
+
+    @property
+    def allows_trading(self) -> bool:
+        """True if trading is allowed (circuit closed)."""
+        return self._state == CircuitState.CLOSED
+
+    @property
+    def stale_symbols(self) -> list[str]:
+        return list(self._stale_symbols)
+
+    def check(self, market_data_service: 'MarketDataService') -> CircuitState:
+        """Evaluate current data freshness and update state.
+
+        Args:
+            market_data_service: The MarketDataService to check for staleness.
+
+        Returns:
+            Current circuit state.
+        """
+        stale = market_data_service.stale_symbols(self.threshold_s)
+
+        if stale:
+            if self._state == CircuitState.CLOSED:
+                # Trip the breaker
+                self._state = CircuitState.OPEN
+                self._tripped_at = time.time()
+                self._stale_symbols = stale
+                self.trip_count += 1
+                logger.warning(
+                    "Circuit breaker OPEN: %d stale focus symbols (threshold=%.1fs): %s",
+                    len(stale), self.threshold_s, stale[:5],
+                )
+            else:
+                self._stale_symbols = stale
+        else:
+            if self._state == CircuitState.OPEN:
+                # Reset the breaker
+                duration = time.time() - self._tripped_at
+                self.last_trip_duration_s = duration
+                self._state = CircuitState.CLOSED
+                self._stale_symbols = []
+                logger.info(
+                    "Circuit breaker CLOSED: data is fresh (was open for %.1fs)", duration,
+                )
+
+        return self._state
+
+    def force_close(self) -> None:
+        """Manually reset the circuit breaker."""
+        self._state = CircuitState.CLOSED
+        self._stale_symbols = []
+
+    def force_open(self, reason: str = "manual") -> None:
+        """Manually trip the circuit breaker."""
+        self._state = CircuitState.OPEN
+        self._tripped_at = time.time()
+        self._stale_symbols = [reason]
+        self.trip_count += 1
+
+    def status_dict(self) -> dict:
+        """Return circuit breaker status as a dict for health reporting."""
+        return {
+            "state": self._state.value,
+            "allows_trading": self.allows_trading,
+            "threshold_s": self.threshold_s,
+            "stale_symbols": self._stale_symbols,
+            "trip_count": self.trip_count,
+            "last_trip_duration_s": self.last_trip_duration_s,
+        }

--- a/services/crypto_trader/config.py
+++ b/services/crypto_trader/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 
 CONFIRM_PHRASE = "I UNDERSTAND THIS IS REAL MONEY"
+KRAKEN_CONFIRM_PHRASE = "I UNDERSTAND THIS IS REAL MONEY ON KRAKEN"
 
 
 def _bool(name: str, default: bool) -> bool:
@@ -18,24 +19,73 @@ def _bool(name: str, default: bool) -> bool:
 class CryptoTraderConfig:
     admin_user_id: str = os.getenv("ADMIN_USER_ID", "")
     mode: str = os.getenv("MODE_LOCK", "paper")
+
+    # ── Broker selection ──
+    broker_type: str = os.getenv("BROKER_TYPE", "paper")  # paper | robinhood | kraken
+
+    # ── Robinhood (legacy) ──
     rh_live_trading: bool = _bool("RH_LIVE_TRADING", False)
     rh_live_confirm: str = os.getenv("RH_LIVE_CONFIRM", "")
+    rh_crypto_api_key: str = os.getenv("RH_CRYPTO_API_KEY", "")
+    rh_crypto_private_key_seed: str = os.getenv("RH_CRYPTO_PRIVATE_KEY_SEED", "")
+    rh_crypto_base_url: str = os.getenv("RH_CRYPTO_BASE_URL", "https://trading.robinhood.com")
+
+    # ── Kraken ──
+    kraken_api_key: str = os.getenv("KRAKEN_API_KEY", "")
+    kraken_api_secret: str = os.getenv("KRAKEN_API_SECRET", "")
+    kraken_base_url: str = os.getenv("KRAKEN_BASE_URL", "https://api.kraken.com")
+    kraken_ws_url: str = os.getenv("KRAKEN_WS_URL", "wss://ws.kraken.com/v2")
+    kraken_ws_auth_url: str = os.getenv("KRAKEN_WS_AUTH_URL", "wss://ws-auth.kraken.com/v2")
+    kraken_live_trading: bool = _bool("KRAKEN_LIVE_TRADING", False)
+    kraken_live_confirm: str = os.getenv("KRAKEN_LIVE_CONFIRM", "")
+
+    # ── Market data source ──
+    market_data_source: str = os.getenv("MARKET_DATA_SOURCE", "polling")  # polling | kraken_ws
+
+    # ── Trade limits ──
     max_notional_per_trade: float = float(os.getenv("MAX_NOTIONAL_PER_TRADE", "25"))
     max_daily_notional: float = float(os.getenv("MAX_DAILY_NOTIONAL", "50"))
     max_open_positions: int = int(os.getenv("MAX_OPEN_POSITIONS", "3"))
     min_notional_per_trade: float = float(os.getenv("MIN_NOTIONAL_PER_TRADE", "15"))
     stop_trading_on_degraded: bool = _bool("STOP_TRADING_ON_DEGRADED", True)
     starting_equity: float = float(os.getenv("STARTING_EQUITY", "2000"))
+
+    # ── Timing ──
     reconcile_interval_seconds: int = int(os.getenv("RECONCILE_INTERVAL_SECONDS", "60"))
     order_poll_interval_seconds: int = int(os.getenv("ORDER_POLL_INTERVAL_SECONDS", "5"))
+
+    # ── Rate limiting (Kraken Intermediate tier) ──
+    kraken_rate_limit_calls: int = int(os.getenv("KRAKEN_RATE_LIMIT_CALLS", "20"))
+    kraken_rate_limit_decay: float = float(os.getenv("KRAKEN_RATE_LIMIT_DECAY", "0.5"))
+
+    # ── Circuit breaker ──
+    stale_data_threshold_s: float = float(os.getenv("STALE_DATA_THRESHOLD_S", "5"))
+    repositioner_timeout_s: float = float(os.getenv("REPOSITIONER_TIMEOUT_S", "300"))
 
     def __post_init__(self) -> None:
         if self.mode not in ("paper", "live"):
             raise ValueError(f"MODE_LOCK must be 'paper' or 'live', got '{self.mode}'")
+        if self.broker_type not in ("paper", "robinhood", "kraken"):
+            raise ValueError(f"BROKER_TYPE must be 'paper', 'robinhood', or 'kraken', got '{self.broker_type}'")
 
     def live_ready(self) -> bool:
-        return self.rh_live_trading and self.rh_live_confirm == CONFIRM_PHRASE
+        """Check if live trading is enabled and confirmed.
+
+        Supports both Robinhood and Kraken brokers:
+        - Robinhood: RH_LIVE_TRADING=true + RH_LIVE_CONFIRM matches CONFIRM_PHRASE
+        - Kraken: KRAKEN_LIVE_TRADING=true + KRAKEN_LIVE_CONFIRM matches KRAKEN_CONFIRM_PHRASE
+        - Paper: always False (paper mode never places real orders)
+        """
+        if self.broker_type == "robinhood":
+            return self.rh_live_trading and self.rh_live_confirm == CONFIRM_PHRASE
+        if self.broker_type == "kraken":
+            return self.kraken_live_trading and self.kraken_live_confirm == KRAKEN_CONFIRM_PHRASE
+        # paper broker is never "live ready"
+        return False
 
     def validate_mode(self) -> None:
         if self.mode == "live" and not self.live_ready():
-            raise RuntimeError("MODE_LOCK=live but live_ready() is False — set RH_LIVE_TRADING=1 and RH_LIVE_CONFIRM")
+            raise RuntimeError(
+                f"MODE_LOCK=live but live_ready() is False for broker_type={self.broker_type}. "
+                "Set the appropriate LIVE_TRADING=1 and LIVE_CONFIRM env vars."
+            )

--- a/services/crypto_trader/fill_processor.py
+++ b/services/crypto_trader/fill_processor.py
@@ -1,0 +1,171 @@
+"""Fill processor — handles incoming execution events from Kraken WS.
+
+Responsibilities:
+  1. Parse execution messages (order status + trade fills)
+  2. Upsert fills to crypto_fills (idempotent on fill_id)
+  3. Update positions table (weighted average cost)
+  4. Record fees in fee_ledger
+  5. Update order intent status
+
+Average cost position tracking:
+  - Buy: new_avg = (old_qty * old_avg + fill_qty * fill_price) / (old_qty + fill_qty)
+  - Sell: realized_pnl = (fill_price - avg_cost) * fill_qty - fee
+           Reduce qty, avg_cost stays the same.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class FillProcessor:
+    """Processes execution events and updates positions/fees."""
+
+    def __init__(self, repository: Any, mode: str = "paper"):
+        self.repo = repository
+        self.mode = mode
+
+    async def handle_execution(self, data: dict[str, Any]) -> None:
+        """Process a Kraken WS v2 executions channel message.
+
+        Message types:
+          - snapshot: initial state on subscribe (snap_orders/snap_trades)
+          - update: real-time order/trade events
+
+        Each message contains a `data` array of execution entries.
+        """
+        msg_type = data.get("type", "")
+        entries = data.get("data", [])
+
+        for entry in entries if isinstance(entries, list) else [entries]:
+            exec_type = entry.get("exec_type", "")
+            if exec_type == "trade":
+                await self._process_fill(entry)
+            elif exec_type in ("new", "pending_new"):
+                await self._process_order_new(entry)
+            elif exec_type in ("canceled", "expired"):
+                await self._process_order_cancel(entry)
+            elif exec_type == "filled":
+                await self._process_order_filled(entry)
+
+    async def _process_fill(self, entry: dict[str, Any]) -> None:
+        """Process a trade fill event."""
+        fill_id = entry.get("trade_id", entry.get("exec_id", ""))
+        order_id = entry.get("order_id", "")
+        symbol = entry.get("symbol", "")
+        side = entry.get("side", "")
+        qty = float(entry.get("last_qty", entry.get("qty", 0)))
+        price = float(entry.get("last_price", entry.get("avg_price", 0)))
+        fee = float(entry.get("fee_paid", entry.get("fee", 0)))
+        fee_currency = entry.get("fee_currency", "USD")
+
+        if not fill_id or qty <= 0:
+            return
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        # 1. Upsert fill (idempotent on fill_id)
+        fill_row = {
+            "order_id": order_id,
+            "fill_id": fill_id,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": price,
+            "fee": fee,
+            "fee_currency": fee_currency,
+            "executed_at": entry.get("timestamp", now_iso),
+            "mode": self.mode,
+        }
+        self.repo.upsert_fill(fill_row)
+
+        # 2. Update position (avg cost method)
+        self._update_position(symbol, side, qty, price, fee)
+
+        # 3. Record fee in ledger
+        fee_usd = fee  # assuming USD-quoted; convert if needed later
+        self.repo.insert_fee_ledger({
+            "fill_id": fill_id,
+            "symbol": symbol,
+            "fee": fee,
+            "fee_currency": fee_currency,
+            "fee_usd": fee_usd,
+            "mode": self.mode,
+        })
+
+        logger.info(
+            "Fill processed: %s %s %s qty=%.8f price=%.4f fee=%.6f %s",
+            fill_id, side, symbol, qty, price, fee, fee_currency,
+        )
+
+    def _update_position(self, symbol: str, side: str, qty: float, price: float, fee: float) -> None:
+        """Update position using weighted average cost method."""
+        pos = self.repo.get_position(symbol, self.mode)
+        old_qty = float(pos.get("qty", 0)) if pos else 0.0
+        old_avg = float(pos.get("avg_cost", 0)) if pos else 0.0
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        if side == "buy":
+            # Average cost: weighted average of old position and new fill
+            # Include fee in cost basis for buys
+            new_qty = old_qty + qty
+            if new_qty > 0:
+                new_avg = (old_qty * old_avg + qty * price + fee) / new_qty
+            else:
+                new_avg = price
+            self.repo.upsert_position({
+                "symbol": symbol,
+                "qty": new_qty,
+                "avg_cost": round(new_avg, 8),
+                "mode": self.mode,
+                "updated_at": now_iso,
+            })
+
+        elif side == "sell":
+            # Sell: reduce qty, avg_cost stays. Realized P&L computed externally.
+            new_qty = max(0.0, old_qty - qty)
+            new_avg = old_avg if new_qty > 0 else 0.0
+            self.repo.upsert_position({
+                "symbol": symbol,
+                "qty": new_qty,
+                "avg_cost": round(new_avg, 8),
+                "mode": self.mode,
+                "updated_at": now_iso,
+            })
+
+    async def _process_order_new(self, entry: dict[str, Any]) -> None:
+        """Handle new order acknowledgment."""
+        order_id = entry.get("order_id", "")
+        cl_oid = entry.get("cl_ord_id", "")
+        if order_id:
+            # Update crypto_orders status
+            self.repo.update_order_status(order_id, "submitted", entry)
+        logger.info("Order new: %s cl_oid=%s", order_id, cl_oid)
+
+    async def _process_order_cancel(self, entry: dict[str, Any]) -> None:
+        """Handle order cancellation."""
+        order_id = entry.get("order_id", "")
+        if order_id:
+            self.repo.update_order_status(order_id, "canceled", entry)
+        logger.info("Order canceled: %s", order_id)
+
+    async def _process_order_filled(self, entry: dict[str, Any]) -> None:
+        """Handle order fully filled event."""
+        order_id = entry.get("order_id", "")
+        if order_id:
+            self.repo.update_order_status(order_id, "filled", entry)
+        logger.info("Order filled: %s", order_id)
+
+    def compute_realized_pnl(self, symbol: str, sell_qty: float, sell_price: float, fee: float) -> float:
+        """Compute realized P&L for a sell using average cost method.
+
+        realized = (sell_price - avg_cost) * qty - fee
+        """
+        pos = self.repo.get_position(symbol, self.mode)
+        avg_cost = float(pos.get("avg_cost", 0)) if pos else 0.0
+        return (sell_price - avg_cost) * sell_qty - fee

--- a/services/crypto_trader/kraken_broker.py
+++ b/services/crypto_trader/kraken_broker.py
@@ -1,0 +1,136 @@
+"""KrakenBroker — Broker implementation backed by Kraken Spot REST API.
+
+Translates the generic Broker interface into Kraken REST calls.
+Handles symbol normalization (internal BTC-USD ↔ Kraken BTC/USD) and
+maps Kraken's response structures to the dict format expected by
+the trader service.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+
+from .broker import Broker
+from .kraken_client import KrakenRestClient, AssetPairInfo
+from .symbol_map import to_kraken, to_internal, normalize_kraken_asset
+
+
+class KrakenBroker(Broker):
+    """Live broker implementation for Kraken Spot."""
+
+    def __init__(self, client: KrakenRestClient):
+        self.client = client
+        # Cache of Kraken pair altnames keyed by friendly symbol ("BTC/USD" → "XBTUSD")
+        self._pair_altnames: dict[str, str] = {}
+
+    async def ensure_pair_cache(self) -> None:
+        """Populate the pair altname cache if empty."""
+        if self._pair_altnames:
+            return
+        pairs = await self.client.get_asset_pairs()
+        for p in pairs:
+            self._pair_altnames[p.symbol] = p.altname
+
+    def _resolve_pair(self, internal_symbol: str) -> str:
+        """Convert internal symbol to Kraken REST pair name.
+
+        Kraken REST endpoints accept altnames (e.g. "XBTUSD") or wsnames.
+        We prefer altname since it's the canonical REST key.
+        Falls back to the slash-separated name if altname not cached.
+        """
+        kraken_sym = to_kraken(internal_symbol)  # "BTC/USD"
+        return self._pair_altnames.get(kraken_sym, kraken_sym)
+
+    # ── Core interface ──
+
+    async def get_cash(self) -> float:
+        balances = await self.client.get_balance()
+        # Sum USD-like balances
+        return sum(
+            v for k, v in balances.items()
+            if k in ("USD", "ZUSD", "USDC", "USDT")
+        )
+
+    async def get_positions(self) -> Dict[str, float]:
+        balances = await self.client.get_balance()
+        positions: Dict[str, float] = {}
+        for asset, qty in balances.items():
+            if asset in ("USD", "ZUSD", "USDC", "USDT"):
+                continue  # skip cash-like
+            if qty > 0:
+                positions[asset] = qty
+        return positions
+
+    async def get_balances(self) -> Dict[str, float]:
+        return await self.client.get_balance()
+
+    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float,
+                          *, order_type: str = "limit", client_order_id: str | None = None) -> Dict[str, Any]:
+        await self.ensure_pair_cache()
+        pair = self._resolve_pair(symbol)
+        cl_oid = client_order_id or f"zoe-{symbol.lower()}-{uuid.uuid4()}"
+
+        result = await self.client.add_order(
+            pair=pair,
+            side=side,
+            order_type=order_type,
+            volume=qty,
+            price=limit_price if order_type == "limit" else None,
+            client_order_id=cl_oid,
+        )
+
+        return {
+            "id": result.order_id,
+            "client_order_id": cl_oid,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "type": order_type,
+            "limit_price": limit_price,
+            "status": result.status,
+            "description": result.description,
+            "raw_response": result.raw,
+        }
+
+    # ── Extended interface ──
+
+    async def cancel_order(self, order_id: str) -> bool:
+        return await self.client.cancel_order(order_id)
+
+    async def get_open_orders(self) -> list[Dict[str, Any]]:
+        orders = await self.client.get_open_orders()
+        return [
+            {
+                "id": o.order_id,
+                "symbol": o.symbol,
+                "side": o.side,
+                "order_type": o.order_type,
+                "price": o.price,
+                "qty": o.qty,
+                "filled_qty": o.filled_qty,
+                "status": o.status,
+                "client_order_id": o.client_order_id,
+                "open_time": o.open_time,
+            }
+            for o in orders
+        ]
+
+    async def get_fills(self, order_id: str) -> list[Dict[str, Any]]:
+        # Kraken doesn't have a per-order fills endpoint; use TradesHistory and filter
+        trades = await self.client.get_trades_history()
+        return [
+            {
+                "fill_id": t.trade_id,
+                "order_id": t.order_id,
+                "symbol": t.symbol,
+                "side": t.side,
+                "qty": t.qty,
+                "price": t.price,
+                "fee": t.fee,
+                "fee_currency": t.fee_currency,
+                "executed_at": t.timestamp,
+            }
+            for t in trades
+            if t.order_id == order_id
+        ]

--- a/services/crypto_trader/kraken_client.py
+++ b/services/crypto_trader/kraken_client.py
@@ -1,0 +1,446 @@
+"""Kraken Spot REST API client with HMAC-SHA512 authentication.
+
+Implements all endpoints needed by the trading bot:
+- Public: AssetPairs, Ticker, Depth, Time
+- Private: Balance, OpenOrders, ClosedOrders, TradesHistory, AddOrder, CancelOrder, GetWebSocketsToken
+
+Authentication follows Kraken's scheme:
+  API-Sign = HMAC-SHA512(base64_decode(api_secret), url_path + SHA256(nonce + post_data))
+
+Rate limiting is handled externally by rate_limiter.py (Phase 5).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import aiohttp
+
+from .symbol_map import normalize_kraken_asset
+
+
+# ── Data classes ──
+
+@dataclass
+class AssetPairInfo:
+    symbol: str             # Kraken WS v2 friendly name, e.g. "BTC/USD"
+    altname: str            # Kraken altname, e.g. "XBTUSD"
+    base: str               # Normalized base, e.g. "BTC"
+    quote: str              # Normalized quote, e.g. "USD"
+    lot_decimals: int
+    pair_decimals: int
+    lot_min: float
+    cost_min: float
+    ordermin: float
+    tick_size: float | None
+    status: str             # "online", "cancel_only", etc.
+
+
+@dataclass
+class TickerData:
+    symbol: str
+    bid: float
+    ask: float
+    last: float
+    volume_24h: float
+    vwap_24h: float
+    high_24h: float
+    low_24h: float
+    open_24h: float
+    trades_24h: int
+
+
+@dataclass
+class OrderInfo:
+    order_id: str
+    symbol: str
+    side: str               # "buy" or "sell"
+    order_type: str         # "limit" or "market"
+    price: float
+    qty: float
+    filled_qty: float
+    status: str             # "open", "closed", "canceled", "expired"
+    client_order_id: str | None
+    open_time: float
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TradeInfo:
+    trade_id: str
+    order_id: str
+    symbol: str
+    side: str
+    qty: float
+    price: float
+    fee: float
+    fee_currency: str
+    timestamp: float
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class OrderResult:
+    order_id: str
+    status: str
+    description: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+# ── Exceptions ──
+
+class KrakenAPIError(Exception):
+    """Raised when Kraken returns an error response."""
+    def __init__(self, errors: list[str], endpoint: str = ""):
+        self.errors = errors
+        self.endpoint = endpoint
+        super().__init__(f"Kraken API error on {endpoint}: {', '.join(errors)}")
+
+
+class KrakenRateLimitError(KrakenAPIError):
+    """Raised specifically for EAPI:Rate limit exceeded."""
+    pass
+
+
+# ── Client ──
+
+class KrakenRestClient:
+    """Async Kraken Spot REST API client."""
+
+    BASE_URL = "https://api.kraken.com"
+
+    def __init__(
+        self,
+        api_key: str = "",
+        api_secret: str = "",
+        base_url: str | None = None,
+        max_retries: int = 3,
+        retry_delay: float = 0.5,
+    ):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.base_url = (base_url or self.BASE_URL).rstrip("/")
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._session: aiohttp.ClientSession | None = None
+        # Nonce must be strictly increasing; use millisecond timestamp
+        self._last_nonce: int = 0
+
+    # ── Session management ──
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    # ── Auth helpers ──
+
+    def _get_nonce(self) -> int:
+        nonce = int(time.time() * 1000)
+        if nonce <= self._last_nonce:
+            nonce = self._last_nonce + 1
+        self._last_nonce = nonce
+        return nonce
+
+    def _sign(self, url_path: str, data: dict[str, Any], nonce: int) -> str:
+        """Compute HMAC-SHA512 signature per Kraken spec."""
+        post_data = urllib.parse.urlencode(data)
+        encoded = (str(nonce) + post_data).encode("utf-8")
+        message = url_path.encode("utf-8") + hashlib.sha256(encoded).digest()
+        secret = base64.b64decode(self.api_secret)
+        mac = hmac.new(secret, message, hashlib.sha512)
+        return base64.b64encode(mac.digest()).decode("utf-8")
+
+    # ── HTTP helpers ──
+
+    async def _public_request(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a public (unauthenticated) GET/POST request."""
+        url = f"{self.base_url}/0/public/{endpoint}"
+        session = await self._get_session()
+
+        for attempt in range(self.max_retries):
+            try:
+                async with session.post(url, data=params or {}) as resp:
+                    data = await resp.json()
+                    errors = data.get("error", [])
+                    if errors:
+                        if any("EAPI:Rate limit" in e for e in errors):
+                            raise KrakenRateLimitError(errors, endpoint)
+                        raise KrakenAPIError(errors, endpoint)
+                    return data.get("result", {})
+            except (aiohttp.ClientError, KrakenRateLimitError) as e:
+                if attempt == self.max_retries - 1:
+                    raise
+                wait = self.retry_delay * (2 ** attempt)
+                await _async_sleep(wait)
+
+        return {}  # unreachable
+
+    async def _private_request(self, endpoint: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make an authenticated POST request."""
+        if not self.api_key or not self.api_secret:
+            raise KrakenAPIError(["Missing API key or secret"], endpoint)
+
+        url_path = f"/0/private/{endpoint}"
+        url = f"{self.base_url}{url_path}"
+        nonce = self._get_nonce()
+
+        post_data = dict(data or {})
+        post_data["nonce"] = nonce
+
+        signature = self._sign(url_path, post_data, nonce)
+        headers = {
+            "API-Key": self.api_key,
+            "API-Sign": signature,
+        }
+
+        session = await self._get_session()
+
+        for attempt in range(self.max_retries):
+            try:
+                async with session.post(url, data=post_data, headers=headers) as resp:
+                    result = await resp.json()
+                    errors = result.get("error", [])
+                    if errors:
+                        if any("EAPI:Rate limit" in e for e in errors):
+                            raise KrakenRateLimitError(errors, endpoint)
+                        raise KrakenAPIError(errors, endpoint)
+                    return result.get("result", {})
+            except (aiohttp.ClientError, KrakenRateLimitError) as e:
+                if attempt == self.max_retries - 1:
+                    raise
+                wait = self.retry_delay * (2 ** attempt)
+                await _async_sleep(wait)
+
+        return {}  # unreachable
+
+    # ── Public endpoints ──
+
+    async def get_server_time(self) -> dict[str, Any]:
+        """GET /0/public/Time — connectivity check."""
+        return await self._public_request("Time")
+
+    async def get_asset_pairs(self) -> list[AssetPairInfo]:
+        """GET /0/public/AssetPairs — all tradeable pairs with metadata."""
+        result = await self._public_request("AssetPairs")
+        pairs: list[AssetPairInfo] = []
+        for key, info in result.items():
+            wsname = info.get("wsname", "")
+            if not wsname or "/" not in wsname:
+                continue
+            base_raw, quote_raw = wsname.split("/", 1)
+            base = normalize_kraken_asset(base_raw)
+            quote = normalize_kraken_asset(quote_raw)
+            pairs.append(AssetPairInfo(
+                symbol=f"{base}/{quote}",
+                altname=info.get("altname", key),
+                base=base,
+                quote=quote,
+                lot_decimals=int(info.get("lot_decimals", 8)),
+                pair_decimals=int(info.get("pair_decimals", 1)),
+                lot_min=float(info.get("lot_minimum", info.get("ordermin", 0))),
+                cost_min=float(info.get("costmin", 0)),
+                ordermin=float(info.get("ordermin", 0)),
+                tick_size=float(info["tick_size"]) if "tick_size" in info else None,
+                status=info.get("status", "online"),
+            ))
+        return pairs
+
+    async def get_ticker(self, symbols: list[str]) -> dict[str, TickerData]:
+        """POST /0/public/Ticker — current ticker for given pairs.
+
+        Args:
+            symbols: List of Kraken pair names (e.g. ["XBTUSD", "ETHUSD"])
+                     or altnames. The API accepts comma-separated pair strings.
+        """
+        result = await self._public_request("Ticker", {"pair": ",".join(symbols)})
+        tickers: dict[str, TickerData] = {}
+        for key, info in result.items():
+            tickers[key] = TickerData(
+                symbol=key,
+                bid=float(info["b"][0]),       # best bid [price, whole_lot_volume, lot_volume]
+                ask=float(info["a"][0]),        # best ask
+                last=float(info["c"][0]),       # last trade price
+                volume_24h=float(info["v"][1]), # volume today (24h)
+                vwap_24h=float(info["p"][1]),   # vwap 24h
+                high_24h=float(info["h"][1]),
+                low_24h=float(info["l"][1]),
+                open_24h=float(info["o"]),
+                trades_24h=int(info["t"][1]),
+            )
+        return tickers
+
+    async def get_order_book(self, pair: str, count: int = 10) -> dict[str, Any]:
+        """POST /0/public/Depth — order book snapshot."""
+        return await self._public_request("Depth", {"pair": pair, "count": count})
+
+    # ── Private endpoints ──
+
+    async def get_balance(self) -> dict[str, float]:
+        """POST /0/private/Balance — all asset balances.
+
+        Returns dict with normalized asset names, e.g. {"BTC": 0.5, "USD": 1000.0}.
+        """
+        result = await self._private_request("Balance")
+        balances: dict[str, float] = {}
+        for asset, amount in result.items():
+            name = normalize_kraken_asset(asset)
+            val = float(amount)
+            if val != 0.0:
+                balances[name] = balances.get(name, 0.0) + val
+        return balances
+
+    async def get_open_orders(self) -> list[OrderInfo]:
+        """POST /0/private/OpenOrders — current working orders."""
+        result = await self._private_request("OpenOrders")
+        orders_raw = result.get("open", {})
+        orders: list[OrderInfo] = []
+        for oid, info in orders_raw.items():
+            descr = info.get("descr", {})
+            orders.append(OrderInfo(
+                order_id=oid,
+                symbol=descr.get("pair", ""),
+                side=descr.get("type", ""),
+                order_type=descr.get("ordertype", ""),
+                price=float(descr.get("price", 0)),
+                qty=float(info.get("vol", 0)),
+                filled_qty=float(info.get("vol_exec", 0)),
+                status=info.get("status", "open"),
+                client_order_id=info.get("userref"),
+                open_time=float(info.get("opentm", 0)),
+                raw=info,
+            ))
+        return orders
+
+    async def get_closed_orders(self, start: float | None = None) -> list[OrderInfo]:
+        """POST /0/private/ClosedOrders — recently closed orders."""
+        params: dict[str, Any] = {}
+        if start is not None:
+            params["start"] = start
+        result = await self._private_request("ClosedOrders", params)
+        orders_raw = result.get("closed", {})
+        orders: list[OrderInfo] = []
+        for oid, info in orders_raw.items():
+            descr = info.get("descr", {})
+            orders.append(OrderInfo(
+                order_id=oid,
+                symbol=descr.get("pair", ""),
+                side=descr.get("type", ""),
+                order_type=descr.get("ordertype", ""),
+                price=float(descr.get("price", 0)),
+                qty=float(info.get("vol", 0)),
+                filled_qty=float(info.get("vol_exec", 0)),
+                status=info.get("status", "closed"),
+                client_order_id=info.get("userref"),
+                open_time=float(info.get("opentm", 0)),
+                raw=info,
+            ))
+        return orders
+
+    async def get_trades_history(self, start: float | None = None) -> list[TradeInfo]:
+        """POST /0/private/TradesHistory — filled trades."""
+        params: dict[str, Any] = {}
+        if start is not None:
+            params["start"] = start
+        result = await self._private_request("TradesHistory", params)
+        trades_raw = result.get("trades", {})
+        trades: list[TradeInfo] = []
+        for tid, info in trades_raw.items():
+            trades.append(TradeInfo(
+                trade_id=tid,
+                order_id=info.get("ordertxid", ""),
+                symbol=info.get("pair", ""),
+                side=info.get("type", ""),
+                qty=float(info.get("vol", 0)),
+                price=float(info.get("price", 0)),
+                fee=float(info.get("fee", 0)),
+                fee_currency=info.get("fee_currency", "USD"),
+                timestamp=float(info.get("time", 0)),
+                raw=info,
+            ))
+        return trades
+
+    async def add_order(
+        self,
+        pair: str,
+        side: str,
+        order_type: str,
+        volume: float,
+        price: float | None = None,
+        client_order_id: str | None = None,
+        validate: bool = False,
+    ) -> OrderResult:
+        """POST /0/private/AddOrder — place a new order.
+
+        Args:
+            pair: Kraken pair name (e.g. "XBTUSD" or use altname).
+            side: "buy" or "sell".
+            order_type: "market" or "limit".
+            volume: Order quantity in base currency units.
+            price: Limit price (required for limit orders).
+            client_order_id: Optional cl_ord_id for idempotency.
+            validate: If True, validate only (no order placed). Used for testing.
+        """
+        data: dict[str, Any] = {
+            "pair": pair,
+            "type": side,
+            "ordertype": order_type,
+            "volume": str(volume),
+        }
+        if price is not None:
+            data["price"] = str(price)
+        if client_order_id:
+            data["cl_ord_id"] = client_order_id
+        if validate:
+            data["validate"] = "true"
+
+        result = await self._private_request("AddOrder", data)
+        txid_list = result.get("txid", [])
+        return OrderResult(
+            order_id=txid_list[0] if txid_list else "",
+            status="submitted",
+            description=result.get("descr", {}).get("order", ""),
+            raw=result,
+        )
+
+    async def cancel_order(self, order_id: str) -> bool:
+        """POST /0/private/CancelOrder — cancel a single order."""
+        result = await self._private_request("CancelOrder", {"txid": order_id})
+        count = result.get("count", 0)
+        return count > 0
+
+    async def cancel_all_orders(self) -> int:
+        """POST /0/private/CancelAll — cancel all open orders."""
+        result = await self._private_request("CancelAll")
+        return result.get("count", 0)
+
+    async def get_ws_token(self) -> str:
+        """POST /0/private/GetWebSocketsToken — get auth token for private WS.
+
+        Requires API key with 'WebSocket Interface' permission enabled.
+        Token expires after ~15 minutes of inactivity.
+        """
+        result = await self._private_request("GetWebSocketsToken")
+        token = result.get("token", "")
+        if not token:
+            raise KrakenAPIError(["No WS token returned"], "GetWebSocketsToken")
+        return token
+
+
+# ── Utility ──
+
+async def _async_sleep(seconds: float) -> None:
+    """Async sleep wrapper (avoids import at top level for minimal deps)."""
+    import asyncio
+    await asyncio.sleep(seconds)

--- a/services/crypto_trader/kraken_ws_manager.py
+++ b/services/crypto_trader/kraken_ws_manager.py
@@ -1,0 +1,273 @@
+"""Kraken WebSocket v2 connection manager.
+
+Handles connection lifecycle for public WS (`wss://ws.kraken.com/v2`):
+  - Connect, subscribe with snapshot, heartbeat monitoring
+  - Auto-reconnect with exponential backoff
+  - Resubscribe all channels on reconnect
+  - Message dispatch to registered callbacks
+
+Usage:
+    mgr = KrakenWsManager(url="wss://ws.kraken.com/v2")
+    mgr.on_ticker(callback)
+    mgr.on_book(callback)
+    mgr.on_trade(callback)
+    await mgr.subscribe_ticker(["BTC/USD", "ETH/USD"])
+    await mgr.run()  # blocks, reconnects on failure
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WsSubscription:
+    """Tracks an active subscription for replay on reconnect."""
+    channel: str               # "ticker", "book", "trade"
+    symbols: list[str]         # ["BTC/USD", "ETH/USD"]
+    params: dict[str, Any] = field(default_factory=dict)  # depth, snapshot, etc.
+    req_id: int = 0
+
+
+MessageCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class KrakenWsManager:
+    """Manages a single Kraken WS v2 public connection."""
+
+    MAX_BACKOFF_S = 30.0
+    HEARTBEAT_TIMEOUT_S = 15.0  # Kraken sends heartbeat every ~5s; stale after 15s
+
+    def __init__(self, url: str = "wss://ws.kraken.com/v2"):
+        self.url = url
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._subscriptions: list[WsSubscription] = []
+        self._req_counter: int = 0
+        self._running = False
+        self._last_message_time: float = 0.0
+        self._reconnect_count: int = 0
+
+        # Callbacks per channel
+        self._on_ticker: list[MessageCallback] = []
+        self._on_book: list[MessageCallback] = []
+        self._on_trade: list[MessageCallback] = []
+        self._on_heartbeat: list[MessageCallback] = []
+        self._on_status: list[MessageCallback] = []
+
+    # ── Callback registration ──
+
+    def on_ticker(self, cb: MessageCallback) -> None:
+        self._on_ticker.append(cb)
+
+    def on_book(self, cb: MessageCallback) -> None:
+        self._on_book.append(cb)
+
+    def on_trade(self, cb: MessageCallback) -> None:
+        self._on_trade.append(cb)
+
+    def on_heartbeat(self, cb: MessageCallback) -> None:
+        self._on_heartbeat.append(cb)
+
+    def on_status(self, cb: MessageCallback) -> None:
+        self._on_status.append(cb)
+
+    # ── Health ──
+
+    @property
+    def connected(self) -> bool:
+        return self._ws is not None and not self._ws.closed
+
+    @property
+    def last_message_age_s(self) -> float:
+        if self._last_message_time == 0:
+            return float("inf")
+        return time.time() - self._last_message_time
+
+    @property
+    def reconnect_count(self) -> int:
+        return self._reconnect_count
+
+    # ── Subscribe helpers ──
+
+    def _next_req_id(self) -> int:
+        self._req_counter += 1
+        return self._req_counter
+
+    async def subscribe_ticker(self, symbols: list[str], event_trigger: str = "bbo") -> None:
+        """Subscribe to ticker (Level-1 BBO) for given symbols."""
+        sub = WsSubscription(
+            channel="ticker",
+            symbols=list(symbols),
+            params={"event_trigger": event_trigger},
+            req_id=self._next_req_id(),
+        )
+        self._subscriptions.append(sub)
+        if self.connected:
+            await self._send_subscribe(sub)
+
+    async def subscribe_book(self, symbols: list[str], depth: int = 10) -> None:
+        """Subscribe to book (Level-2 order book) for given symbols."""
+        sub = WsSubscription(
+            channel="book",
+            symbols=list(symbols),
+            params={"depth": depth, "snapshot": True},
+            req_id=self._next_req_id(),
+        )
+        self._subscriptions.append(sub)
+        if self.connected:
+            await self._send_subscribe(sub)
+
+    async def subscribe_trade(self, symbols: list[str], snapshot: bool = True) -> None:
+        """Subscribe to individual trade events for given symbols."""
+        sub = WsSubscription(
+            channel="trade",
+            symbols=list(symbols),
+            params={"snapshot": snapshot},
+            req_id=self._next_req_id(),
+        )
+        self._subscriptions.append(sub)
+        if self.connected:
+            await self._send_subscribe(sub)
+
+    async def _send_subscribe(self, sub: WsSubscription) -> None:
+        """Send a subscribe message over the WS connection."""
+        if not self._ws or self._ws.closed:
+            return
+        msg: dict[str, Any] = {
+            "method": "subscribe",
+            "params": {
+                "channel": sub.channel,
+                "symbol": sub.symbols,
+                **sub.params,
+            },
+        }
+        if sub.req_id:
+            msg["req_id"] = sub.req_id
+        await self._ws.send_json(msg)
+        logger.info("WS subscribe: channel=%s symbols=%s req_id=%d", sub.channel, sub.symbols, sub.req_id)
+
+    async def _resubscribe_all(self) -> None:
+        """Replay all subscriptions after reconnect."""
+        for sub in self._subscriptions:
+            sub.req_id = self._next_req_id()
+            await self._send_subscribe(sub)
+
+    # ── Connection lifecycle ──
+
+    async def run(self) -> None:
+        """Main loop: connect, listen, reconnect on failure. Blocks forever."""
+        self._running = True
+        backoff = 1.0
+
+        while self._running:
+            try:
+                await self._connect()
+                await self._resubscribe_all()
+                backoff = 1.0  # reset on successful connect
+                await self._listen()
+            except (aiohttp.ClientError, asyncio.TimeoutError, ConnectionError) as e:
+                logger.warning("WS connection lost: %s. Reconnecting in %.1fs...", e, backoff)
+            except Exception as e:
+                logger.error("WS unexpected error: %s. Reconnecting in %.1fs...", e, backoff)
+            finally:
+                await self._close_ws()
+
+            if self._running:
+                self._reconnect_count += 1
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self.MAX_BACKOFF_S)
+
+    async def stop(self) -> None:
+        """Gracefully stop the connection loop."""
+        self._running = False
+        await self._close_ws()
+
+    async def _connect(self) -> None:
+        """Open a new WS connection."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        self._ws = await self._session.ws_connect(self.url, heartbeat=10.0)
+        self._last_message_time = time.time()
+        logger.info("WS connected to %s", self.url)
+        await self._dispatch_status({"event": "connected", "url": self.url})
+
+    async def _close_ws(self) -> None:
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+    async def _listen(self) -> None:
+        """Read messages until connection drops."""
+        assert self._ws is not None
+        async for msg in self._ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                self._last_message_time = time.time()
+                try:
+                    data = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    logger.warning("WS invalid JSON: %s", msg.data[:200])
+                    continue
+                await self._dispatch(data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                logger.error("WS error: %s", self._ws.exception())
+                break
+            elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
+                logger.info("WS closed by server")
+                break
+
+    # ── Message dispatch ──
+
+    async def _dispatch(self, data: dict[str, Any]) -> None:
+        """Route incoming WS message to appropriate callbacks."""
+        channel = data.get("channel")
+        msg_type = data.get("type")
+
+        if channel == "heartbeat":
+            for cb in self._on_heartbeat:
+                await cb(data)
+            return
+
+        if channel == "status":
+            await self._dispatch_status(data)
+            return
+
+        if msg_type in ("subscribe", "unsubscribe"):
+            # Subscription ack/error
+            success = data.get("success", False)
+            if not success:
+                logger.error("WS subscription failed: %s", data)
+            return
+
+        # Data messages
+        if channel == "ticker":
+            for cb in self._on_ticker:
+                await cb(data)
+        elif channel == "book":
+            for cb in self._on_book:
+                await cb(data)
+        elif channel == "trade":
+            for cb in self._on_trade:
+                await cb(data)
+
+    async def _dispatch_status(self, data: dict[str, Any]) -> None:
+        for cb in self._on_status:
+            await cb(data)
+
+    # ── Cleanup ──
+
+    async def close(self) -> None:
+        """Close connection and session."""
+        await self._close_ws()
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None

--- a/services/crypto_trader/kraken_ws_private.py
+++ b/services/crypto_trader/kraken_ws_private.py
@@ -1,0 +1,203 @@
+"""Kraken authenticated WebSocket v2 client for private feeds.
+
+Connects to wss://ws-auth.kraken.com/v2 with a token from REST
+GetWebSocketsToken endpoint. Subscribes to:
+  - executions: order status changes + trade fills
+  - balances (optional): real-time balance updates
+
+On each execution event, dispatches to registered callbacks.
+Handles reconnection with token refresh.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Callable, Coroutine
+
+import aiohttp
+
+from .kraken_client import KrakenRestClient
+
+logger = logging.getLogger(__name__)
+
+MessageCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class KrakenWsPrivate:
+    """Manages the authenticated Kraken WS v2 connection."""
+
+    MAX_BACKOFF_S = 30.0
+    TOKEN_REFRESH_MARGIN_S = 600  # refresh token 10 min before expected expiry
+
+    def __init__(
+        self,
+        rest_client: KrakenRestClient,
+        ws_auth_url: str = "wss://ws-auth.kraken.com/v2",
+    ):
+        self.rest = rest_client
+        self.ws_auth_url = ws_auth_url
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._token: str = ""
+        self._token_acquired_at: float = 0.0
+        self._running = False
+        self._last_message_time: float = 0.0
+        self._reconnect_count: int = 0
+
+        # Callbacks
+        self._on_execution: list[MessageCallback] = []
+        self._on_balance: list[MessageCallback] = []
+
+    # ── Callback registration ──
+
+    def on_execution(self, cb: MessageCallback) -> None:
+        """Register callback for execution events (order fills, status changes)."""
+        self._on_execution.append(cb)
+
+    def on_balance(self, cb: MessageCallback) -> None:
+        """Register callback for balance updates."""
+        self._on_balance.append(cb)
+
+    # ── Health ──
+
+    @property
+    def connected(self) -> bool:
+        return self._ws is not None and not self._ws.closed
+
+    @property
+    def last_message_age_s(self) -> float:
+        if self._last_message_time == 0:
+            return float("inf")
+        return time.time() - self._last_message_time
+
+    # ── Token management ──
+
+    async def _ensure_token(self) -> str:
+        """Get or refresh the WS authentication token."""
+        now = time.time()
+        # Token lasts ~15 min; refresh if > 10 min old
+        if self._token and (now - self._token_acquired_at) < self.TOKEN_REFRESH_MARGIN_S:
+            return self._token
+        self._token = await self.rest.get_ws_token()
+        self._token_acquired_at = now
+        logger.info("WS auth token acquired/refreshed")
+        return self._token
+
+    # ── Connection lifecycle ──
+
+    async def run(self) -> None:
+        """Main loop: connect, authenticate, listen, reconnect on failure."""
+        self._running = True
+        backoff = 1.0
+
+        while self._running:
+            try:
+                token = await self._ensure_token()
+                await self._connect()
+                await self._subscribe(token)
+                backoff = 1.0
+                await self._listen()
+            except (aiohttp.ClientError, asyncio.TimeoutError, ConnectionError) as e:
+                logger.warning("Private WS connection lost: %s. Reconnecting in %.1fs...", e, backoff)
+            except Exception as e:
+                logger.error("Private WS unexpected error: %s. Reconnecting in %.1fs...", e, backoff)
+            finally:
+                await self._close_ws()
+
+            if self._running:
+                self._reconnect_count += 1
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self.MAX_BACKOFF_S)
+
+    async def stop(self) -> None:
+        self._running = False
+        await self._close_ws()
+
+    async def _connect(self) -> None:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        self._ws = await self._session.ws_connect(self.ws_auth_url, heartbeat=10.0)
+        self._last_message_time = time.time()
+        logger.info("Private WS connected to %s", self.ws_auth_url)
+
+    async def _close_ws(self) -> None:
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+    async def _subscribe(self, token: str) -> None:
+        """Subscribe to executions (and optionally balances) with auth token."""
+        if not self._ws or self._ws.closed:
+            return
+
+        # Subscribe to executions (orders + fills)
+        exec_msg = {
+            "method": "subscribe",
+            "params": {
+                "channel": "executions",
+                "token": token,
+                "snap_orders": True,
+                "snap_trades": True,
+            },
+        }
+        await self._ws.send_json(exec_msg)
+        logger.info("Private WS: subscribed to executions")
+
+        # Subscribe to balances
+        bal_msg = {
+            "method": "subscribe",
+            "params": {
+                "channel": "balances",
+                "token": token,
+                "snap_orders": False,
+            },
+        }
+        await self._ws.send_json(bal_msg)
+        logger.info("Private WS: subscribed to balances")
+
+    async def _listen(self) -> None:
+        assert self._ws is not None
+        async for msg in self._ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                self._last_message_time = time.time()
+                try:
+                    data = json.loads(msg.data)
+                except json.JSONDecodeError:
+                    continue
+                await self._dispatch(data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                logger.error("Private WS error: %s", self._ws.exception())
+                break
+            elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
+                logger.info("Private WS closed by server")
+                break
+
+    async def _dispatch(self, data: dict[str, Any]) -> None:
+        channel = data.get("channel")
+        msg_type = data.get("type")
+
+        if channel == "heartbeat":
+            return
+
+        if msg_type in ("subscribe", "unsubscribe"):
+            success = data.get("success", False)
+            if not success:
+                logger.error("Private WS subscription failed: %s", data)
+            return
+
+        if channel == "executions":
+            for cb in self._on_execution:
+                await cb(data)
+
+        elif channel == "balances":
+            for cb in self._on_balance:
+                await cb(data)
+
+    async def close(self) -> None:
+        await self._close_ws()
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None

--- a/services/crypto_trader/market_data_service.py
+++ b/services/crypto_trader/market_data_service.py
@@ -1,0 +1,477 @@
+"""Scout/Focus market data service backed by Kraken WS v2.
+
+Two tiers:
+  - Focus (~10-50 symbols): Subscribed to ticker+book+trade, coalesced every 500ms,
+    flushed to `market_snapshot_focus`. Drives trading logic and dashboard.
+  - Scout (~200 USD+stablecoin pairs): Subscribed to ticker only, coalesced every 10s,
+    flushed to `market_snapshot_scout`. Used for mover detection and promotion.
+
+Promotion logic: volume spike > 2x, price move > 0.5%, spread < 0.2% → promote to focus.
+Demotion: after 10 min of inactivity (no trades, no signal), demote back to scout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .kraken_client import KrakenRestClient, AssetPairInfo
+from .kraken_ws_manager import KrakenWsManager
+from .symbol_map import is_usd_or_stablecoin_quoted
+
+logger = logging.getLogger(__name__)
+
+# Default focus symbols (major USD pairs)
+DEFAULT_FOCUS = [
+    "BTC/USD", "ETH/USD", "SOL/USD", "LTC/USD",
+    "XRP/USD", "ADA/USD", "DOGE/USD",
+]
+
+FOCUS_FLUSH_INTERVAL_S = 0.5
+SCOUT_FLUSH_INTERVAL_S = 10.0
+PROMOTION_COOLDOWN_S = 600  # 10 min in focus before eligible for demotion
+
+
+@dataclass
+class TickerSnapshot:
+    """In-memory buffer for a single symbol's latest ticker data."""
+    symbol: str
+    bid: float = 0.0
+    ask: float = 0.0
+    mid: float = 0.0
+    last_price: float = 0.0
+    volume_24h: float = 0.0
+    change_pct_24h: float = 0.0
+    spread_bps: float = 0.0
+    updated_at: float = 0.0  # time.time()
+
+    # For promotion detection
+    prev_volume_1h: float = 0.0
+    prev_mid_5m: float = 0.0
+
+
+@dataclass
+class CatalogEntry:
+    """Cached pair metadata from Kraken AssetPairs."""
+    symbol: str
+    base: str
+    quote: str
+    lot_decimals: int
+    pair_decimals: int
+    lot_min: float
+    cost_min: float
+    ordermin: float
+    tick_size: float | None
+    status: str
+
+
+class MarketDataService:
+    """Manages WS subscriptions, coalescing, and DB flushing."""
+
+    def __init__(
+        self,
+        rest_client: KrakenRestClient,
+        ws_manager: KrakenWsManager,
+        repository: Any,  # SupabaseCryptoRepository
+        focus_symbols: list[str] | None = None,
+    ):
+        self.rest = rest_client
+        self.ws = ws_manager
+        self.repo = repository
+
+        # Symbol sets
+        self._focus_set: set[str] = set(focus_symbols or DEFAULT_FOCUS)
+        self._scout_set: set[str] = set()
+
+        # In-memory coalescing buffers
+        self._focus_buffer: dict[str, TickerSnapshot] = {}
+        self._scout_buffer: dict[str, TickerSnapshot] = {}
+
+        # Catalog cache
+        self._catalog: dict[str, CatalogEntry] = {}
+
+        # Promotion tracking: symbol → time promoted
+        self._promotion_times: dict[str, float] = {}
+
+        # Flush timing
+        self._last_focus_flush: float = 0.0
+        self._last_scout_flush: float = 0.0
+
+        # Running state
+        self._running = False
+        self._tasks: list[asyncio.Task] = []
+
+    # ── Startup ──
+
+    async def initialize(self) -> None:
+        """Load catalog from REST, set up scout universe, wire WS callbacks."""
+        logger.info("MarketDataService initializing...")
+
+        # 1. Fetch all pairs from Kraken
+        pairs = await self.rest.get_asset_pairs()
+        for p in pairs:
+            self._catalog[p.symbol] = CatalogEntry(
+                symbol=p.symbol,
+                base=p.base,
+                quote=p.quote,
+                lot_decimals=p.lot_decimals,
+                pair_decimals=p.pair_decimals,
+                lot_min=p.lot_min,
+                cost_min=p.cost_min,
+                ordermin=p.ordermin,
+                tick_size=p.tick_size,
+                status=p.status,
+            )
+
+        # Persist catalog to DB
+        catalog_rows = [
+            {
+                "symbol": c.symbol,
+                "base_asset": c.base,
+                "quote_asset": c.quote,
+                "lot_decimals": c.lot_decimals,
+                "pair_decimals": c.pair_decimals,
+                "lot_min": c.lot_min,
+                "cost_min": c.cost_min,
+                "ordermin": c.ordermin,
+                "tick_size": c.tick_size,
+                "status": c.status,
+            }
+            for c in self._catalog.values()
+        ]
+        self.repo.upsert_market_catalog(catalog_rows)
+        logger.info("Catalog loaded: %d pairs total", len(self._catalog))
+
+        # 2. Build scout universe: USD + USDT + USDC quoted, online, not in focus
+        for sym, entry in self._catalog.items():
+            if entry.status != "online":
+                continue
+            if not is_usd_or_stablecoin_quoted(sym):
+                continue
+            if sym not in self._focus_set:
+                self._scout_set.add(sym)
+
+        logger.info("Focus: %d symbols, Scout: %d symbols", len(self._focus_set), len(self._scout_set))
+
+        # 3. Register WS callbacks
+        self.ws.on_ticker(self._handle_ticker)
+        self.ws.on_book(self._handle_book)
+        self.ws.on_trade(self._handle_trade)
+
+    async def start(self) -> None:
+        """Subscribe to WS channels and start flush loops."""
+        self._running = True
+
+        # Subscribe focus: ticker + book + trade
+        focus_list = sorted(self._focus_set)
+        if focus_list:
+            await self.ws.subscribe_ticker(focus_list)
+            await self.ws.subscribe_book(focus_list, depth=10)
+            await self.ws.subscribe_trade(focus_list)
+
+        # Subscribe scout: ticker only
+        scout_list = sorted(self._scout_set)
+        if scout_list:
+            # Subscribe in batches of 100 to avoid overwhelming
+            for i in range(0, len(scout_list), 100):
+                batch = scout_list[i:i+100]
+                await self.ws.subscribe_ticker(batch)
+
+        # Start flush loops
+        self._tasks.append(asyncio.create_task(self._focus_flush_loop()))
+        self._tasks.append(asyncio.create_task(self._scout_flush_loop()))
+        self._tasks.append(asyncio.create_task(self._promotion_loop()))
+
+        logger.info("MarketDataService started: focus=%d scout=%d", len(focus_list), len(scout_list))
+
+    async def stop(self) -> None:
+        self._running = False
+        for t in self._tasks:
+            t.cancel()
+        self._tasks.clear()
+
+    # ── WS message handlers ──
+
+    async def _handle_ticker(self, data: dict[str, Any]) -> None:
+        """Process incoming ticker (Level-1) message."""
+        msg_data = data.get("data", [])
+        for tick in msg_data if isinstance(msg_data, list) else [msg_data]:
+            symbol = tick.get("symbol", "")
+            if not symbol:
+                continue
+
+            bid = float(tick.get("bid", 0))
+            ask = float(tick.get("ask", 0))
+            last = float(tick.get("last", 0))
+            volume = float(tick.get("volume", 0))
+            change_pct = float(tick.get("change_pct", tick.get("change", 0)))
+
+            mid = (bid + ask) / 2 if bid > 0 and ask > 0 else last
+            spread_bps = ((ask - bid) / mid * 10000) if mid > 0 else 0
+
+            snap = TickerSnapshot(
+                symbol=symbol,
+                bid=bid,
+                ask=ask,
+                mid=mid,
+                last_price=last,
+                volume_24h=volume,
+                change_pct_24h=change_pct,
+                spread_bps=spread_bps,
+                updated_at=time.time(),
+            )
+
+            if symbol in self._focus_set:
+                existing = self._focus_buffer.get(symbol)
+                if existing:
+                    snap.prev_volume_1h = existing.prev_volume_1h
+                    snap.prev_mid_5m = existing.prev_mid_5m
+                self._focus_buffer[symbol] = snap
+            else:
+                existing = self._scout_buffer.get(symbol)
+                if existing:
+                    snap.prev_volume_1h = existing.prev_volume_1h
+                    snap.prev_mid_5m = existing.prev_mid_5m
+                self._scout_buffer[symbol] = snap
+
+    async def _handle_book(self, data: dict[str, Any]) -> None:
+        """Process book updates — extract best bid/ask for focus snapshots."""
+        msg_data = data.get("data", [])
+        for update in msg_data if isinstance(msg_data, list) else [msg_data]:
+            symbol = update.get("symbol", "")
+            if not symbol or symbol not in self._focus_set:
+                continue
+
+            bids = update.get("bids", [])
+            asks = update.get("asks", [])
+
+            if bids and asks:
+                best_bid = float(bids[0].get("price", 0))
+                best_ask = float(asks[0].get("price", 0))
+                if best_bid > 0 and best_ask > 0:
+                    snap = self._focus_buffer.get(symbol)
+                    if snap:
+                        snap.bid = best_bid
+                        snap.ask = best_ask
+                        snap.mid = (best_bid + best_ask) / 2
+                        snap.spread_bps = (best_ask - best_bid) / snap.mid * 10000 if snap.mid > 0 else 0
+                        snap.updated_at = time.time()
+
+    async def _handle_trade(self, data: dict[str, Any]) -> None:
+        """Process trade events — update last price for focus symbols."""
+        msg_data = data.get("data", [])
+        for trade in msg_data if isinstance(msg_data, list) else [msg_data]:
+            symbol = trade.get("symbol", "")
+            price = float(trade.get("price", 0))
+            if symbol and price > 0 and symbol in self._focus_set:
+                snap = self._focus_buffer.get(symbol)
+                if snap:
+                    snap.last_price = price
+                    snap.updated_at = time.time()
+
+    # ── Flush loops ──
+
+    async def _focus_flush_loop(self) -> None:
+        """Flush focus buffer to DB every FOCUS_FLUSH_INTERVAL_S."""
+        while self._running:
+            try:
+                await asyncio.sleep(FOCUS_FLUSH_INTERVAL_S)
+                await self._flush_focus()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Focus flush error: %s", e)
+
+    async def _scout_flush_loop(self) -> None:
+        """Flush scout buffer to DB every SCOUT_FLUSH_INTERVAL_S."""
+        while self._running:
+            try:
+                await asyncio.sleep(SCOUT_FLUSH_INTERVAL_S)
+                await self._flush_scout()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Scout flush error: %s", e)
+
+    async def _flush_focus(self) -> None:
+        """Write focus snapshots to market_snapshot_focus."""
+        if not self._focus_buffer:
+            return
+        now_iso = datetime.now(timezone.utc).isoformat()
+        rows = [
+            {
+                "symbol": s.symbol,
+                "bid": s.bid,
+                "ask": s.ask,
+                "mid": s.mid,
+                "last_price": s.last_price,
+                "volume_24h": s.volume_24h,
+                "change_pct_24h": s.change_pct_24h,
+                "spread_bps": s.spread_bps,
+                "updated_at": now_iso,
+            }
+            for s in self._focus_buffer.values()
+            if s.updated_at > 0
+        ]
+        if rows:
+            self.repo.upsert_market_snapshot_focus(rows)
+
+    async def _flush_scout(self) -> None:
+        """Write scout snapshots to market_snapshot_scout."""
+        if not self._scout_buffer:
+            return
+        now_iso = datetime.now(timezone.utc).isoformat()
+        rows = [
+            {
+                "symbol": s.symbol,
+                "mid": s.mid,
+                "volume_24h": s.volume_24h,
+                "change_pct_24h": s.change_pct_24h,
+                "updated_at": now_iso,
+            }
+            for s in self._scout_buffer.values()
+            if s.updated_at > 0
+        ]
+        if rows:
+            self.repo.upsert_market_snapshot_scout(rows)
+
+    # ── Promotion / Demotion ──
+
+    async def _promotion_loop(self) -> None:
+        """Periodically check scout symbols for promotion criteria."""
+        while self._running:
+            try:
+                await asyncio.sleep(30.0)  # check every 30s
+                await self._check_promotions()
+                await self._check_demotions()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Promotion loop error: %s", e)
+
+    async def _check_promotions(self) -> None:
+        """Promote scout symbols to focus if they meet criteria."""
+        now = time.time()
+        to_promote: list[str] = []
+
+        for symbol, snap in self._scout_buffer.items():
+            if symbol in self._focus_set:
+                continue
+            if snap.updated_at == 0:
+                continue
+
+            # Criteria: volume spike > 2x, price move > 0.5%, spread < 20 bps (0.2%)
+            score = 0
+            if snap.prev_volume_1h > 0 and snap.volume_24h > snap.prev_volume_1h * 2:
+                score += 2
+            if snap.prev_mid_5m > 0:
+                price_move = abs(snap.mid / snap.prev_mid_5m - 1)
+                if price_move > 0.005:
+                    score += 1
+            if 0 < snap.spread_bps < 20:
+                score += 1
+
+            if score >= 3:
+                to_promote.append(symbol)
+
+        for sym in to_promote:
+            await self._promote(sym)
+
+    async def _check_demotions(self) -> None:
+        """Demote focus symbols back to scout after inactivity."""
+        now = time.time()
+        default_focus = set(DEFAULT_FOCUS)
+        to_demote: list[str] = []
+
+        for sym, promoted_at in list(self._promotion_times.items()):
+            if sym in default_focus:
+                continue  # never demote defaults
+            if now - promoted_at > PROMOTION_COOLDOWN_S:
+                snap = self._focus_buffer.get(sym)
+                if snap and now - snap.updated_at > 60:
+                    # No recent data — demote
+                    to_demote.append(sym)
+
+        for sym in to_demote:
+            await self._demote(sym)
+
+    async def _promote(self, symbol: str) -> None:
+        """Move a symbol from scout to focus."""
+        if symbol in self._focus_set:
+            return
+        logger.info("PROMOTE %s: scout → focus", symbol)
+        self._focus_set.add(symbol)
+        self._scout_set.discard(symbol)
+        self._promotion_times[symbol] = time.time()
+
+        # Move buffer entry
+        if symbol in self._scout_buffer:
+            self._focus_buffer[symbol] = self._scout_buffer.pop(symbol)
+
+        # Subscribe to book + trade (ticker already subscribed)
+        await self.ws.subscribe_book([symbol], depth=10)
+        await self.ws.subscribe_trade([symbol])
+
+    async def _demote(self, symbol: str) -> None:
+        """Move a symbol from focus back to scout."""
+        if symbol not in self._focus_set:
+            return
+        if symbol in DEFAULT_FOCUS:
+            return  # never demote core symbols
+        logger.info("DEMOTE %s: focus → scout", symbol)
+        self._focus_set.discard(symbol)
+        self._scout_set.add(symbol)
+        self._promotion_times.pop(symbol, None)
+
+        # Move buffer entry
+        if symbol in self._focus_buffer:
+            self._scout_buffer[symbol] = self._focus_buffer.pop(symbol)
+
+    # ── Public API ──
+
+    def get_focus_snapshot(self, symbol: str) -> TickerSnapshot | None:
+        """Get the latest in-memory snapshot for a focus symbol."""
+        return self._focus_buffer.get(symbol)
+
+    def get_all_focus_snapshots(self) -> dict[str, TickerSnapshot]:
+        return dict(self._focus_buffer)
+
+    def get_scout_snapshot(self, symbol: str) -> TickerSnapshot | None:
+        return self._scout_buffer.get(symbol)
+
+    @property
+    def focus_symbols(self) -> set[str]:
+        return set(self._focus_set)
+
+    @property
+    def scout_symbols(self) -> set[str]:
+        return set(self._scout_set)
+
+    @property
+    def catalog(self) -> dict[str, CatalogEntry]:
+        return dict(self._catalog)
+
+    def is_data_stale(self, threshold_s: float = 5.0) -> bool:
+        """Check if any focus symbol has stale data (older than threshold)."""
+        now = time.time()
+        for sym in self._focus_set:
+            snap = self._focus_buffer.get(sym)
+            if snap is None or snap.updated_at == 0:
+                continue  # never received data — might be new
+            if now - snap.updated_at > threshold_s:
+                return True
+        return False
+
+    def stale_symbols(self, threshold_s: float = 5.0) -> list[str]:
+        """List focus symbols with data older than threshold."""
+        now = time.time()
+        stale: list[str] = []
+        for sym in self._focus_set:
+            snap = self._focus_buffer.get(sym)
+            if snap and snap.updated_at > 0 and now - snap.updated_at > threshold_s:
+                stale.append(sym)
+        return stale

--- a/services/crypto_trader/order_executor.py
+++ b/services/crypto_trader/order_executor.py
@@ -1,0 +1,138 @@
+"""Idempotent order executor with intent tracking and trade locks.
+
+Every order goes through this lifecycle:
+  1. Create OrderIntent in DB (status=pending)
+  2. Acquire trade lock on symbol
+  3. Submit order via Broker (status=submitted)
+  4. On fill: update intent + positions via FillProcessor (status=filled)
+  5. Release trade lock
+
+Idempotency: if client_order_id already exists, skip submission.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from .broker import Broker
+
+logger = logging.getLogger(__name__)
+
+
+class OrderExecutor:
+    """Places orders through the intent→submit→track pipeline."""
+
+    def __init__(self, broker: Broker, repository: Any, mode: str = "paper"):
+        self.broker = broker
+        self.repo = repository
+        self.mode = mode
+
+    async def submit_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty: float,
+        limit_price: float | None = None,
+        order_type: str = "limit",
+        strategy: str | None = None,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Submit an order through the intent pipeline.
+
+        Returns the order result dict from the broker.
+        Raises on failure (but intent is always recorded).
+        """
+        client_order_id = f"zoe-{symbol.lower().replace('/', '-')}-{uuid.uuid4()}"
+        intent_id = str(uuid.uuid4())
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        # 1. Record intent
+        intent = {
+            "intent_id": intent_id,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "limit_price": limit_price,
+            "order_type": order_type,
+            "strategy": strategy,
+            "reason": reason,
+            "status": "pending",
+            "client_order_id": client_order_id,
+            "mode": self.mode,
+            "created_at": now_iso,
+        }
+        self.repo.upsert_order_intent(intent)
+        logger.info("Intent created: %s %s %s qty=%.8f cl_oid=%s", intent_id, side, symbol, qty, client_order_id)
+
+        # 2. Acquire trade lock
+        lock_acquired = self.repo.acquire_trade_lock(symbol, self.mode, locked_by=intent_id)
+        if not lock_acquired:
+            self.repo.update_order_intent_status(intent_id, "rejected", reason="trade_lock_busy")
+            raise RuntimeError(f"Trade lock busy for {symbol} (mode={self.mode})")
+
+        try:
+            # 3. Check idempotency — skip if already submitted
+            # (client_order_id unique constraint will catch duplicates at DB level)
+
+            # 4. Submit to broker
+            result = await self.broker.place_order(
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                limit_price=limit_price or 0,
+                order_type=order_type,
+                client_order_id=client_order_id,
+            )
+
+            # 5. Update intent status
+            broker_status = result.get("status", "submitted")
+            self.repo.update_order_intent_status(
+                intent_id,
+                broker_status,
+                submitted_at=now_iso,
+            )
+
+            # 6. Also record in crypto_orders for dashboard compatibility
+            order_row = {
+                "id": result.get("id", client_order_id),
+                "client_order_id": client_order_id,
+                "intent_id": intent_id,
+                "symbol": symbol,
+                "side": side,
+                "order_type": order_type,
+                "qty": qty,
+                "notional": qty * (limit_price or 0),
+                "status": broker_status,
+                "raw_response": result.get("raw_response", {}),
+                "mode": self.mode,
+            }
+            self.repo.insert_order(order_row)
+
+            logger.info(
+                "Order submitted: %s %s %s qty=%.8f → status=%s order_id=%s",
+                intent_id, side, symbol, qty, broker_status, result.get("id", "?")
+            )
+            return result
+
+        except Exception as e:
+            self.repo.update_order_intent_status(intent_id, "rejected", reason=str(e))
+            logger.error("Order submission failed for intent %s: %s", intent_id, e)
+            raise
+
+        finally:
+            # 7. Release trade lock
+            self.repo.release_trade_lock(symbol, self.mode)
+
+    async def cancel_order(self, order_id: str, intent_id: str | None = None) -> bool:
+        """Cancel an open order and update intent status."""
+        success = await self.broker.cancel_order(order_id)
+        if success and intent_id:
+            self.repo.update_order_intent_status(
+                intent_id, "cancelled",
+                resolved_at=datetime.now(timezone.utc).isoformat(),
+            )
+        return success

--- a/services/crypto_trader/pnl_service.py
+++ b/services/crypto_trader/pnl_service.py
@@ -1,0 +1,139 @@
+"""P&L computation service.
+
+Computes:
+  - Per-position unrealized P&L: (mid_price - avg_cost) * qty
+  - Portfolio realized P&L: sum of all closed trades' gains/losses
+  - Cumulative fees from fee_ledger
+  - Gross equity: cash + sum(qty * mid_price)
+  - Net equity: gross - cumulative fees (already deducted from cash, but tracked separately)
+
+Writes enhanced pnl_daily snapshots with gross_equity, fees_usd, positions_count.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PnlSnapshot:
+    date: str
+    gross_equity: float
+    realized_pnl: float
+    unrealized_pnl: float
+    fees_usd: float
+    positions_count: int
+    cash_usd: float
+
+
+class PnlService:
+    """Computes and persists P&L snapshots."""
+
+    def __init__(self, repository: Any, mode: str = "paper"):
+        self.repo = repository
+        self.mode = mode
+
+    def compute_snapshot(self, cash_usd: float, focus_prices: dict[str, float]) -> PnlSnapshot:
+        """Compute a full P&L snapshot.
+
+        Args:
+            cash_usd: Current USD cash balance.
+            focus_prices: Dict of symbol → mid price from market_snapshot_focus.
+
+        Returns:
+            PnlSnapshot with all computed fields.
+        """
+        positions = self.repo.list_positions(self.mode)
+        positions_count = len(positions)
+
+        # Unrealized P&L and crypto value
+        unrealized_pnl = 0.0
+        crypto_value = 0.0
+
+        for pos in positions:
+            symbol = pos.get("symbol", "")
+            qty = float(pos.get("qty", 0))
+            avg_cost = float(pos.get("avg_cost", 0))
+            mid = focus_prices.get(symbol, 0.0)
+
+            if qty > 0 and mid > 0:
+                pos_value = qty * mid
+                crypto_value += pos_value
+                unrealized_pnl += (mid - avg_cost) * qty
+
+        # Gross equity = cash + crypto holdings at market value
+        gross_equity = cash_usd + crypto_value
+
+        # Realized P&L from fills
+        realized_pnl = self.repo.get_realized_pnl(self.mode)
+
+        # Cumulative fees
+        fees_usd = self.repo.get_cumulative_fees(self.mode)
+
+        return PnlSnapshot(
+            date=str(date.today()),
+            gross_equity=round(gross_equity, 4),
+            realized_pnl=round(realized_pnl, 4),
+            unrealized_pnl=round(unrealized_pnl, 4),
+            fees_usd=round(fees_usd, 4),
+            positions_count=positions_count,
+            cash_usd=round(cash_usd, 4),
+        )
+
+    def write_snapshot(self, snap: PnlSnapshot) -> None:
+        """Persist a P&L snapshot to pnl_daily."""
+        try:
+            self.repo.upsert_pnl_daily({
+                "date": snap.date,
+                "instance_id": "default",
+                "equity": snap.gross_equity,
+                "gross_equity": snap.gross_equity,
+                "daily_pnl": snap.realized_pnl,
+                "drawdown": 0,
+                "cash_buffer_pct": (snap.cash_usd / snap.gross_equity * 100) if snap.gross_equity > 0 else 100,
+                "day_trades_used": 0,
+                "realized_pnl": snap.realized_pnl,
+                "unrealized_pnl": snap.unrealized_pnl,
+                "fees_usd": snap.fees_usd,
+                "positions_count": snap.positions_count,
+                "mode": self.mode,
+            })
+        except Exception as e:
+            logger.error("PnL snapshot write error: %s", e)
+
+    def compute_and_write(self, cash_usd: float, focus_prices: dict[str, float]) -> PnlSnapshot:
+        """Convenience: compute + persist in one call."""
+        snap = self.compute_snapshot(cash_usd, focus_prices)
+        self.write_snapshot(snap)
+        return snap
+
+    def get_position_pnl(self, symbol: str, mid_price: float) -> dict[str, Any]:
+        """Get P&L breakdown for a single position.
+
+        Returns dict with qty, avg_cost, market_value, unrealized_pnl, unrealized_pnl_pct.
+        """
+        pos = self.repo.get_position(symbol, self.mode)
+        if not pos:
+            return {"symbol": symbol, "qty": 0, "avg_cost": 0, "market_value": 0,
+                    "unrealized_pnl": 0, "unrealized_pnl_pct": 0}
+
+        qty = float(pos.get("qty", 0))
+        avg_cost = float(pos.get("avg_cost", 0))
+        market_value = qty * mid_price if mid_price > 0 else 0
+        cost_basis = qty * avg_cost
+        unrealized = market_value - cost_basis
+        pct = (unrealized / cost_basis * 100) if cost_basis > 0 else 0
+
+        return {
+            "symbol": symbol,
+            "qty": qty,
+            "avg_cost": round(avg_cost, 8),
+            "market_value": round(market_value, 4),
+            "unrealized_pnl": round(unrealized, 4),
+            "unrealized_pnl_pct": round(pct, 2),
+        }

--- a/services/crypto_trader/rate_limiter.py
+++ b/services/crypto_trader/rate_limiter.py
@@ -1,0 +1,78 @@
+"""Token bucket rate limiter for Kraken REST API.
+
+Kraken Intermediate tier: 20 tokens, refill 0.5/s.
+Each REST call consumes 1 token (history calls may consume 2).
+
+Usage:
+    limiter = RateLimiter(capacity=20, refill_rate=0.5)
+    await limiter.acquire()  # blocks if no tokens available
+    # ... make REST call ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+
+class RateLimiter:
+    """Async token bucket rate limiter."""
+
+    def __init__(self, capacity: int = 20, refill_rate: float = 0.5):
+        """
+        Args:
+            capacity: Maximum tokens in the bucket.
+            refill_rate: Tokens added per second.
+        """
+        self.capacity = capacity
+        self.refill_rate = refill_rate
+        self._tokens: float = float(capacity)
+        self._last_refill: float = time.monotonic()
+        self._lock = asyncio.Lock()
+
+        # Stats
+        self.total_acquired: int = 0
+        self.total_waited: float = 0.0
+
+    def _refill(self) -> None:
+        """Add tokens based on elapsed time since last refill."""
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        self._tokens = min(self.capacity, self._tokens + elapsed * self.refill_rate)
+        self._last_refill = now
+
+    async def acquire(self, cost: int = 1) -> float:
+        """Acquire `cost` tokens, blocking if necessary.
+
+        Returns the time waited in seconds (0.0 if no wait).
+        """
+        waited = 0.0
+        async with self._lock:
+            self._refill()
+
+            while self._tokens < cost:
+                # Calculate how long we need to wait for enough tokens
+                deficit = cost - self._tokens
+                wait_time = deficit / self.refill_rate
+                await asyncio.sleep(wait_time)
+                waited += wait_time
+                self._refill()
+
+            self._tokens -= cost
+            self.total_acquired += 1
+            self.total_waited += waited
+
+        return waited
+
+    @property
+    def available_tokens(self) -> float:
+        """Current token count (approximate, no lock)."""
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        return min(self.capacity, self._tokens + elapsed * self.refill_rate)
+
+    def __repr__(self) -> str:
+        return (
+            f"RateLimiter(capacity={self.capacity}, refill_rate={self.refill_rate}, "
+            f"tokens={self.available_tokens:.1f}, acquired={self.total_acquired})"
+        )

--- a/services/crypto_trader/repositioner.py
+++ b/services/crypto_trader/repositioner.py
@@ -1,0 +1,95 @@
+"""Repositioner — cancels stale limit orders that haven't filled.
+
+Runs periodically to clean up unfilled limit orders beyond a configurable
+timeout (default: 5 minutes / 300 seconds). This prevents capital from
+being locked up in stale orders.
+
+Can also be extended to replace (cancel + resubmit) orders at a better price.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from .broker import Broker
+
+logger = logging.getLogger(__name__)
+
+
+class Repositioner:
+    """Monitors open limit orders and cancels stale ones."""
+
+    def __init__(
+        self,
+        broker: Broker,
+        repository: Any,
+        mode: str = "paper",
+        timeout_s: float = 300.0,  # 5 minutes
+    ):
+        self.broker = broker
+        self.repo = repository
+        self.mode = mode
+        self.timeout_s = timeout_s
+
+    async def check_and_cancel_stale(self) -> list[str]:
+        """Cancel open orders older than timeout_s.
+
+        Returns list of cancelled order IDs.
+        """
+        open_orders = self.repo.list_open_orders(self.mode)
+        now = time.time()
+        cancelled: list[str] = []
+
+        for order in open_orders:
+            order_id = order.get("id", "")
+            requested_at = order.get("requested_at", "")
+            order_type = order.get("order_type", "")
+
+            # Only cancel limit orders (market orders should fill immediately)
+            if order_type != "limit":
+                continue
+
+            # Parse timestamp and check age
+            if not requested_at:
+                continue
+
+            try:
+                from datetime import datetime, timezone
+                if isinstance(requested_at, str):
+                    # Handle ISO format with timezone
+                    ts = datetime.fromisoformat(requested_at.replace("Z", "+00:00"))
+                    order_age_s = (datetime.now(timezone.utc) - ts).total_seconds()
+                else:
+                    continue
+            except (ValueError, TypeError):
+                continue
+
+            if order_age_s > self.timeout_s:
+                try:
+                    success = await self.broker.cancel_order(order_id)
+                    if success:
+                        self.repo.update_order_status(order_id, "canceled", {
+                            "cancel_reason": "repositioner_timeout",
+                            "age_seconds": order_age_s,
+                        })
+                        # Also update intent if linked
+                        intent_id = order.get("intent_id")
+                        if intent_id:
+                            self.repo.update_order_intent_status(
+                                intent_id, "cancelled",
+                                reason="repositioner_timeout",
+                            )
+                        cancelled.append(order_id)
+                        logger.info(
+                            "Repositioner cancelled stale order %s (age=%.0fs, timeout=%.0fs)",
+                            order_id, order_age_s, self.timeout_s,
+                        )
+                except Exception as e:
+                    logger.error("Repositioner failed to cancel %s: %s", order_id, e)
+
+        if cancelled:
+            logger.info("Repositioner cancelled %d stale orders", len(cancelled))
+
+        return cancelled

--- a/services/crypto_trader/symbol_map.py
+++ b/services/crypto_trader/symbol_map.py
@@ -1,0 +1,89 @@
+"""Bidirectional symbol normalization between internal format and Kraken WS v2 format.
+
+Internal format: "BTC-USD" (dash-separated, used throughout existing codebase)
+Kraken format:   "BTC/USD" (slash-separated, used by Kraken WS v2)
+Kraken legacy:   "XXBTZUSD" (X-prefixed, used by some REST endpoints)
+
+Kraken uses "XBT" internally for Bitcoin but WS v2 uses "BTC".
+"""
+
+from __future__ import annotations
+
+# Kraken-specific asset aliases (WS v2 uses friendly names, REST may use legacy)
+_KRAKEN_TO_FRIENDLY: dict[str, str] = {
+    "XBT": "BTC",
+    "XDG": "DOGE",
+}
+_FRIENDLY_TO_KRAKEN: dict[str, str] = {v: k for k, v in _KRAKEN_TO_FRIENDLY.items()}
+
+
+def to_kraken(internal_symbol: str) -> str:
+    """Convert internal format to Kraken WS v2 format.
+
+    >>> to_kraken("BTC-USD")
+    'BTC/USD'
+    >>> to_kraken("ETH-USD")
+    'ETH/USD'
+    >>> to_kraken("DOGE-USDT")
+    'DOGE/USDT'
+    """
+    parts = internal_symbol.strip().upper().split("-")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid internal symbol format: {internal_symbol!r} (expected BASE-QUOTE)")
+    return f"{parts[0]}/{parts[1]}"
+
+
+def to_internal(kraken_symbol: str) -> str:
+    """Convert Kraken WS v2 format to internal format.
+
+    >>> to_internal("BTC/USD")
+    'BTC-USD'
+    >>> to_internal("ETH/USD")
+    'ETH-USD'
+    """
+    parts = kraken_symbol.strip().upper().split("/")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid Kraken symbol format: {kraken_symbol!r} (expected BASE/QUOTE)")
+    base = _KRAKEN_TO_FRIENDLY.get(parts[0], parts[0])
+    quote = _KRAKEN_TO_FRIENDLY.get(parts[1], parts[1])
+    return f"{base}-{quote}"
+
+
+def normalize_kraken_asset(asset: str) -> str:
+    """Normalize a Kraken asset code to friendly name.
+
+    >>> normalize_kraken_asset("XBT")
+    'BTC'
+    >>> normalize_kraken_asset("XDG")
+    'DOGE'
+    >>> normalize_kraken_asset("ETH")
+    'ETH'
+    >>> normalize_kraken_asset("ZUSD")
+    'USD'
+    """
+    upper = asset.strip().upper()
+    # Strip Z/X prefix used in Kraken legacy REST (e.g. ZUSD -> USD, XXBT -> XBT)
+    if len(upper) == 4 and upper[0] in ("Z", "X") and upper[1:] not in _KRAKEN_TO_FRIENDLY:
+        stripped = upper[1:]
+        return _KRAKEN_TO_FRIENDLY.get(stripped, stripped)
+    return _KRAKEN_TO_FRIENDLY.get(upper, upper)
+
+
+def is_usd_or_stablecoin_quoted(symbol: str) -> bool:
+    """Check if a Kraken symbol is quoted in USD, USDT, or USDC.
+
+    Works with both internal ("BTC-USD") and Kraken ("BTC/USD") formats.
+
+    >>> is_usd_or_stablecoin_quoted("BTC/USD")
+    True
+    >>> is_usd_or_stablecoin_quoted("ETH-USDT")
+    True
+    >>> is_usd_or_stablecoin_quoted("BTC/EUR")
+    False
+    """
+    upper = symbol.strip().upper()
+    for sep in ("/", "-"):
+        if sep in upper:
+            quote = upper.rsplit(sep, 1)[1]
+            return quote in ("USD", "USDT", "USDC")
+    return False

--- a/services/crypto_trader/test_connectivity.py
+++ b/services/crypto_trader/test_connectivity.py
@@ -1,0 +1,257 @@
+"""Kraken connectivity smoke test.
+
+Run this script to verify:
+  1. REST public endpoints work (Time, AssetPairs, Ticker)
+  2. REST private endpoints work (Balance, GetWebSocketsToken) — requires API keys
+  3. WS v2 public connection works (subscribe ticker for BTC/USD)
+  4. Symbol normalization round-trips correctly
+
+Usage:
+    python -m services.crypto_trader.test_connectivity
+
+Environment variables required for private tests:
+    KRAKEN_API_KEY, KRAKEN_API_SECRET
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+
+
+async def test_public_rest() -> bool:
+    """Test public REST endpoints."""
+    from .kraken_client import KrakenRestClient
+    client = KrakenRestClient()
+
+    print("\n=== PUBLIC REST ===")
+
+    # 1. Server time
+    try:
+        result = await client.get_server_time()
+        print(f"  [OK] Server time: {result}")
+    except Exception as e:
+        print(f"  [FAIL] Server time: {e}")
+        await client.close()
+        return False
+
+    # 2. Asset pairs
+    try:
+        pairs = await client.get_asset_pairs()
+        usd_pairs = [p for p in pairs if p.quote == "USD"]
+        usdt_pairs = [p for p in pairs if p.quote == "USDT"]
+        usdc_pairs = [p for p in pairs if p.quote == "USDC"]
+        print(f"  [OK] Asset pairs: {len(pairs)} total, {len(usd_pairs)} USD, {len(usdt_pairs)} USDT, {len(usdc_pairs)} USDC")
+        # Show a few examples
+        for p in pairs[:3]:
+            print(f"       {p.symbol} (altname={p.altname}, lot_min={p.lot_min}, cost_min={p.cost_min})")
+    except Exception as e:
+        print(f"  [FAIL] Asset pairs: {e}")
+        await client.close()
+        return False
+
+    # 3. Ticker
+    try:
+        tickers = await client.get_ticker(["XBTUSD", "ETHUSD"])
+        for key, t in tickers.items():
+            print(f"  [OK] Ticker {key}: bid={t.bid}, ask={t.ask}, last={t.last}, vol24h={t.volume_24h}")
+    except Exception as e:
+        print(f"  [FAIL] Ticker: {e}")
+        await client.close()
+        return False
+
+    await client.close()
+    return True
+
+
+async def test_private_rest() -> bool:
+    """Test private REST endpoints (requires API keys)."""
+    from .kraken_client import KrakenRestClient
+
+    api_key = os.getenv("KRAKEN_API_KEY", "")
+    api_secret = os.getenv("KRAKEN_API_SECRET", "")
+
+    if not api_key or not api_secret:
+        print("\n=== PRIVATE REST (SKIPPED — no API keys) ===")
+        return True
+
+    client = KrakenRestClient(api_key=api_key, api_secret=api_secret)
+    print("\n=== PRIVATE REST ===")
+
+    # 1. Balance
+    try:
+        balances = await client.get_balance()
+        print(f"  [OK] Balances: {len(balances)} assets")
+        for asset, amount in sorted(balances.items()):
+            print(f"       {asset}: {amount}")
+    except Exception as e:
+        print(f"  [FAIL] Balance: {e}")
+        await client.close()
+        return False
+
+    # 2. Open orders
+    try:
+        orders = await client.get_open_orders()
+        print(f"  [OK] Open orders: {len(orders)}")
+    except Exception as e:
+        print(f"  [FAIL] Open orders: {e}")
+
+    # 3. WS token
+    try:
+        token = await client.get_ws_token()
+        print(f"  [OK] WS token: {token[:20]}...")
+    except Exception as e:
+        print(f"  [FAIL] WS token: {e}")
+
+    # 4. Validate-only order (no real order placed)
+    try:
+        result = await client.add_order(
+            pair="XBTUSD",
+            side="buy",
+            order_type="limit",
+            volume=0.0001,
+            price=10000.0,  # well below market
+            validate=True,
+        )
+        print(f"  [OK] Validate order: {result.description}")
+    except Exception as e:
+        print(f"  [FAIL] Validate order: {e}")
+
+    await client.close()
+    return True
+
+
+async def test_ws_public() -> bool:
+    """Test WS v2 public connection with ticker subscription."""
+    from .kraken_ws_manager import KrakenWsManager
+
+    print("\n=== WS v2 PUBLIC ===")
+    mgr = KrakenWsManager()
+    received: list[dict] = []
+
+    async def on_ticker(data: dict) -> None:
+        received.append(data)
+
+    mgr.on_ticker(on_ticker)
+
+    try:
+        # Connect and subscribe
+        await mgr._connect()
+        await mgr.subscribe_ticker(["BTC/USD"])
+        await mgr._resubscribe_all()
+
+        # Listen for up to 10 seconds
+        print("  Listening for ticker messages (10s)...")
+        start = time.time()
+        while time.time() - start < 10:
+            if mgr._ws and not mgr._ws.closed:
+                try:
+                    msg = await asyncio.wait_for(mgr._ws.receive(), timeout=2.0)
+                    if msg.type == 1:  # TEXT
+                        import json
+                        data = json.loads(msg.data)
+                        await mgr._dispatch(data)
+                except asyncio.TimeoutError:
+                    pass
+            if received:
+                break
+
+        if received:
+            print(f"  [OK] Received {len(received)} ticker message(s)")
+            sample = received[0]
+            data = sample.get("data", [])
+            if data:
+                tick = data[0] if isinstance(data, list) else data
+                print(f"       symbol={tick.get('symbol')} bid={tick.get('bid')} ask={tick.get('ask')}")
+        else:
+            print("  [WARN] No ticker messages received in 10s")
+
+        await mgr.close()
+        return bool(received)
+
+    except Exception as e:
+        print(f"  [FAIL] WS: {e}")
+        await mgr.close()
+        return False
+
+
+def test_symbol_map() -> bool:
+    """Test symbol normalization."""
+    from .symbol_map import to_kraken, to_internal, normalize_kraken_asset, is_usd_or_stablecoin_quoted
+
+    print("\n=== SYMBOL MAP ===")
+    tests = [
+        ("BTC-USD", "BTC/USD"),
+        ("ETH-USD", "ETH/USD"),
+        ("SOL-USDT", "SOL/USDT"),
+        ("DOGE-USDC", "DOGE/USDC"),
+    ]
+
+    ok = True
+    for internal, kraken in tests:
+        result = to_kraken(internal)
+        back = to_internal(kraken)
+        match = result == kraken and back == internal
+        status = "[OK]" if match else "[FAIL]"
+        print(f"  {status} {internal} ↔ {kraken} (got: {result}, back: {back})")
+        if not match:
+            ok = False
+
+    # Asset normalization
+    asset_tests = [("XBT", "BTC"), ("XDG", "DOGE"), ("ETH", "ETH"), ("ZUSD", "USD")]
+    for raw, expected in asset_tests:
+        result = normalize_kraken_asset(raw)
+        match = result == expected
+        status = "[OK]" if match else "[FAIL]"
+        print(f"  {status} normalize({raw}) = {result} (expected {expected})")
+        if not match:
+            ok = False
+
+    # Stablecoin check
+    stablecoin_tests = [("BTC/USD", True), ("ETH-USDT", True), ("BTC/EUR", False)]
+    for sym, expected in stablecoin_tests:
+        result = is_usd_or_stablecoin_quoted(sym)
+        match = result == expected
+        status = "[OK]" if match else "[FAIL]"
+        print(f"  {status} is_usd_or_stablecoin({sym}) = {result} (expected {expected})")
+        if not match:
+            ok = False
+
+    return ok
+
+
+async def main() -> None:
+    print("=" * 60)
+    print("  KRAKEN CONNECTIVITY SMOKE TEST")
+    print("=" * 60)
+
+    results: dict[str, bool] = {}
+
+    results["symbol_map"] = test_symbol_map()
+    results["public_rest"] = await test_public_rest()
+    results["private_rest"] = await test_private_rest()
+    results["ws_public"] = await test_ws_public()
+
+    print("\n" + "=" * 60)
+    print("  RESULTS")
+    print("=" * 60)
+    all_passed = True
+    for name, passed in results.items():
+        status = "PASS" if passed else "FAIL"
+        print(f"  {status}: {name}")
+        if not passed:
+            all_passed = False
+
+    print()
+    if all_passed:
+        print("  ALL TESTS PASSED")
+    else:
+        print("  SOME TESTS FAILED")
+    print("=" * 60)
+    sys.exit(0 if all_passed else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/crypto_trader/trader.py
+++ b/services/crypto_trader/trader.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Any
 
-from integrations.robinhood_crypto_client import RobinhoodCryptoClient
-from integrations.robinhood_crypto_client.client import _sanitize
-
+from .broker import Broker
 from .candle_manager import CandleManager
 from .config import CONFIRM_PHRASE, CryptoTraderConfig
 from .logger import JsonAuditLogger
@@ -19,6 +18,8 @@ from .scanner import scan_candidates
 from .signals import generate_signals, Signal
 from .exit_manager import SmartExitManager, ExitConfig, ExitReason, ExitUrgency
 from .consensus import ConsensusEngine
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -32,8 +33,31 @@ class HealthState:
 
 
 class CryptoTraderService:
-    def __init__(self, client: RobinhoodCryptoClient, repository: CryptoRepository, config: CryptoTraderConfig | None = None):
-        self.client = client
+    """Main trading loop — broker-agnostic.
+
+    Supports three broker backends (paper / robinhood / kraken) and two
+    market-data sources (polling / kraken_ws), selectable via config flags.
+    """
+
+    def __init__(
+        self,
+        broker: Broker,
+        repository: CryptoRepository,
+        config: CryptoTraderConfig | None = None,
+        *,
+        # Optional Kraken components — injected by the startup harness
+        market_data_service: Any | None = None,
+        order_executor: Any | None = None,
+        fill_processor: Any | None = None,
+        pnl_service: Any | None = None,
+        repositioner: Any | None = None,
+        circuit_breaker: Any | None = None,
+        ws_private: Any | None = None,
+        ws_manager: Any | None = None,
+        # Legacy compatibility: raw RH client for polling path
+        rh_client: Any | None = None,
+    ):
+        self.broker = broker
         self.repo = repository
         self.cfg = config or CryptoTraderConfig()
         self.mode = self.cfg.mode
@@ -52,6 +76,24 @@ class CryptoTraderService:
         self._safe_mode_until: float = 0.0
         self._cycle_count: int = 0
         self._next_historical_refresh: float = 0.0
+
+        # ── New Kraken components (None if not using Kraken) ──
+        self.market_data = market_data_service
+        self.order_executor = order_executor
+        self.fill_processor = fill_processor
+        self.pnl_service = pnl_service
+        self.repositioner = repositioner
+        self.circuit_breaker = circuit_breaker
+        self.ws_private = ws_private
+        self.ws_manager = ws_manager
+
+        # Legacy RH client for polling path (when market_data_source=polling)
+        self._rh_client = rh_client
+
+        # Background tasks (WS loops, etc.)
+        self._background_tasks: list[asyncio.Task] = []
+
+    # ── Admin controls ──
 
     def _require_admin(self, initiator_id: str) -> None:
         if initiator_id != self.cfg.admin_user_id:
@@ -80,9 +122,14 @@ class CryptoTraderService:
 
     def _validate_symbol(self, symbol: str) -> str:
         normalized = symbol.strip().upper()
-        if not normalized.endswith("-USD"):
-            raise ValueError("Only Robinhood crypto USD pairs are allowed")
-        return normalized
+        # Accept both dash-separated (BTC-USD) and slash-separated (BTC/USD)
+        if normalized.endswith("-USD") or normalized.endswith("/USD"):
+            return normalized
+        if normalized.endswith("-USDT") or normalized.endswith("/USDT"):
+            return normalized
+        if normalized.endswith("-USDC") or normalized.endswith("/USDC"):
+            return normalized
+        raise ValueError(f"Only USD/USDT/USDC quoted pairs are allowed, got: {symbol}")
 
     def _enforce_trade_limits(self, *, notional: float, symbol: str) -> None:
         if notional > self.cfg.max_notional_per_trade:
@@ -96,6 +143,8 @@ class CryptoTraderService:
         if symbol not in open_positions and len(open_positions) >= self.cfg.max_open_positions:
             raise ValueError("Trade blocked by MAX_OPEN_POSITIONS")
 
+    # ── Order placement ──
+
     async def place_order(self, *, initiator_id: str, symbol: str, side: str, notional: float | None = None, qty: float | None = None, order_type: str = "market", limit_price: float | None = None) -> dict[str, Any]:
         self._require_admin(initiator_id)
         if self._paused:
@@ -107,37 +156,55 @@ class CryptoTraderService:
         if time.time() < self._safe_mode_until:
             raise RuntimeError("Trading blocked: boot safe-mode cooldown active")
 
+        # Circuit breaker guard
+        if self.circuit_breaker and self.circuit_breaker.is_open:
+            raise RuntimeError("Trading blocked: circuit breaker OPEN (stale market data)")
+
         safe_symbol = self._validate_symbol(symbol)
         order_notional = notional or ((qty or 0) * (limit_price or 0))
         self._enforce_trade_limits(notional=order_notional, symbol=safe_symbol)
 
-        client_order_id = f"zoe-{safe_symbol.lower()}-{uuid.uuid4()}"
-        order = await self.client.place_order(
-            symbol=safe_symbol,
-            side=side,
-            order_type=order_type,
-            client_order_id=client_order_id,
-            notional=notional,
-            qty=qty,
-            limit_price=limit_price,
-        )
-        self.repo.insert_order(
-            {
-                "id": order.get("id", client_order_id),
-                "client_order_id": client_order_id,
-                "symbol": safe_symbol,
-                "side": side,
-                "order_type": order_type,
-                "qty": qty,
-                "notional": notional,
-                "status": order.get("status", "submitted"),
-                "raw_response": _sanitize(order),
-                "mode": self.mode,
-            }
-        )
+        client_order_id = f"zoe-{safe_symbol.lower().replace('/', '-')}-{uuid.uuid4()}"
+
+        # Use OrderExecutor if available (Kraken path), otherwise direct broker call
+        if self.order_executor and qty:
+            result = await self.order_executor.submit_order(
+                symbol=safe_symbol,
+                side=side,
+                qty=qty,
+                limit_price=limit_price,
+                order_type=order_type,
+                strategy="manual",
+                reason="manual_order",
+            )
+        else:
+            # Legacy path: direct broker call (RH or PaperBroker)
+            result = await self.broker.place_order(
+                symbol=safe_symbol,
+                side=side,
+                qty=qty or 0,
+                limit_price=limit_price or 0,
+                order_type=order_type,
+                client_order_id=client_order_id,
+            )
+            self.repo.insert_order(
+                {
+                    "id": result.get("id", client_order_id),
+                    "client_order_id": client_order_id,
+                    "symbol": safe_symbol,
+                    "side": side,
+                    "order_type": order_type,
+                    "qty": qty,
+                    "notional": notional,
+                    "status": result.get("status", "submitted"),
+                    "raw_response": result,
+                    "mode": self.mode,
+                }
+            )
+
         self.repo.set_daily_notional(date.today(), self.repo.get_daily_notional(date.today(), self.mode) + order_notional, self.mode)
         self.audit.write("crypto_order_submitted", symbol=safe_symbol, side=side, notional=order_notional, client_order_id=client_order_id, mode=self.mode)
-        return order
+        return result
 
     def _compute_local_ledger(self) -> tuple[float, dict[str, float]]:
         start_cash = float((self.repo.latest_cash_snapshot(self.mode) or {}).get("cash_available", 0.0))
@@ -155,31 +222,43 @@ class CryptoTraderService:
             local_cash += cash_delta
         return local_cash, holdings
 
+    # ── Reconciliation ──
+
     async def reconcile(self) -> HealthState:
         if self.mode == "paper":
             return await self._reconcile_paper()
         return await self._reconcile_live()
 
     async def _reconcile_paper(self) -> HealthState:
-        """Paper mode: use local ledger only, no Robinhood API calls."""
-        local_cash, local_holdings = self._compute_local_ledger()
-        # If no fills yet, use starting equity from config
-        if local_cash == 0.0 and not local_holdings:
-            local_cash = float(getattr(self.cfg, "starting_equity", 2000.0))
+        """Paper mode: use broker-reported state."""
+        cash = await self.broker.get_cash()
+        positions = await self.broker.get_positions()
 
-        total_value = 0.0  # Paper mode doesn't track market value
-        self.repo.insert_cash_snapshot(cash_available=local_cash, buying_power=local_cash, mode=self.mode)
-        self.repo.insert_holdings_snapshot(holdings=local_holdings, total_value=total_value, mode=self.mode)
+        # If no fills yet, use starting equity from config
+        if cash == 0.0 and not positions:
+            cash = float(getattr(self.cfg, "starting_equity", 2000.0))
+
+        total_value = 0.0
+
+        # If we have market data, compute total value
+        if self.market_data:
+            for sym, qty in positions.items():
+                snap = self.market_data.get_focus_snapshot(sym)
+                if snap and snap.mid > 0:
+                    total_value += qty * snap.mid
+
+        self.repo.insert_cash_snapshot(cash_available=cash, buying_power=cash, mode=self.mode)
+        self.repo.insert_holdings_snapshot(holdings=positions, total_value=total_value, mode=self.mode)
         self.repo.insert_reconciliation_event(
             {
                 "taken_at": datetime.now(timezone.utc).isoformat(),
-                "local_cash": local_cash,
-                "rh_cash": local_cash,
+                "local_cash": cash,
+                "broker_cash": cash,
                 "cash_diff": 0.0,
-                "local_holdings": local_holdings,
-                "rh_holdings": local_holdings,
+                "local_holdings": positions,
+                "broker_holdings": positions,
                 "status": "ok",
-                "reason": "paper mode - local ledger only",
+                "reason": "paper mode - broker ledger",
                 "mode": self.mode,
             }
         )
@@ -194,39 +273,43 @@ class CryptoTraderService:
         )
 
     async def _reconcile_live(self) -> HealthState:
-        """Live mode: reconcile against real Robinhood API."""
-        balances = await self.client.get_account_balances()
-        holdings_resp = await self.client.get_holdings()
+        """Live mode: reconcile against real broker API."""
+        broker_cash = await self.broker.get_cash()
+        broker_positions = await self.broker.get_positions()
+        broker_buying_power = broker_cash
 
-        rh_cash = float(balances.get("cash_available") or balances.get("cash") or 0.0)
-        rh_buying_power = float(balances.get("buying_power") or rh_cash)
-        rh_holdings = {item["symbol"]: float(item.get("quantity", 0.0)) for item in holdings_resp.get("results", holdings_resp if isinstance(holdings_resp, list) else [])}
-        total_value = sum(float(item.get("market_value", 0.0)) for item in holdings_resp.get("results", [])) if isinstance(holdings_resp, dict) else 0.0
+        # Compute total value using market data
+        total_value = 0.0
+        if self.market_data:
+            for sym, qty in broker_positions.items():
+                snap = self.market_data.get_focus_snapshot(sym)
+                if snap and snap.mid > 0:
+                    total_value += qty * snap.mid
 
         local_cash, local_holdings = self._compute_local_ledger()
-        cash_diff = local_cash - rh_cash
+        cash_diff = local_cash - broker_cash
         holding_diff = {
-            sym: local_holdings.get(sym, 0.0) - rh_holdings.get(sym, 0.0)
-            for sym in sorted(set(local_holdings) | set(rh_holdings))
-            if abs(local_holdings.get(sym, 0.0) - rh_holdings.get(sym, 0.0)) > 0.0000001
+            sym: local_holdings.get(sym, 0.0) - broker_positions.get(sym, 0.0)
+            for sym in sorted(set(local_holdings) | set(broker_positions))
+            if abs(local_holdings.get(sym, 0.0) - broker_positions.get(sym, 0.0)) > 0.0000001
         }
 
         status = "ok"
         reason = ""
         if abs(cash_diff) > 1 or holding_diff:
             status = "degraded"
-            reason = "Mismatch between local ledger and Robinhood snapshots"
+            reason = "Mismatch between local ledger and broker snapshots"
 
-        self.repo.insert_cash_snapshot(cash_available=rh_cash, buying_power=rh_buying_power, mode=self.mode)
-        self.repo.insert_holdings_snapshot(holdings=rh_holdings, total_value=total_value, mode=self.mode)
+        self.repo.insert_cash_snapshot(cash_available=broker_cash, buying_power=broker_buying_power, mode=self.mode)
+        self.repo.insert_holdings_snapshot(holdings=broker_positions, total_value=total_value, mode=self.mode)
         self.repo.insert_reconciliation_event(
             {
                 "taken_at": datetime.now(timezone.utc).isoformat(),
                 "local_cash": local_cash,
-                "rh_cash": rh_cash,
+                "broker_cash": broker_cash,
                 "cash_diff": cash_diff,
                 "local_holdings": local_holdings,
-                "rh_holdings": rh_holdings,
+                "broker_holdings": broker_positions,
                 "holdings_diff": holding_diff,
                 "status": status,
                 "reason": reason,
@@ -243,13 +326,36 @@ class CryptoTraderService:
 
         return self.get_health(reason_override=reason)
 
+    # ── Order polling ──
+
     async def poll_open_orders(self) -> None:
+        """Poll open orders for status updates.
+
+        When using Kraken WS private feed, fills arrive via WS callbacks
+        and this method only does REST-based reconciliation as fallback.
+        """
+        if self.cfg.broker_type == "kraken" and self.ws_private and self.ws_private.connected:
+            # WS-driven fill processing is active — only do lightweight REST check
+            await self._poll_open_orders_broker()
+            return
+
+        if self._rh_client:
+            # Legacy RH polling path
+            await self._poll_open_orders_rh()
+            return
+
+        # Generic broker path
+        await self._poll_open_orders_broker()
+
+    async def _poll_open_orders_rh(self) -> None:
+        """Legacy Robinhood order polling via RH client."""
+        from integrations.robinhood_crypto_client.client import _sanitize
         for order in self.repo.list_open_orders(self.mode):
-            rh_order = await self.client.get_order(order["id"])
+            rh_order = await self._rh_client.get_order(order["id"])
             status = rh_order.get("status", order.get("status", "submitted"))
             self.repo.update_order_status(order["id"], status, _sanitize(rh_order))
 
-            fills = await self.client.get_order_fills(order["id"])
+            fills = await self._rh_client.get_order_fills(order["id"])
             for fill in fills.get("results", fills if isinstance(fills, list) else []):
                 self.repo.upsert_fill(
                     {
@@ -267,10 +373,44 @@ class CryptoTraderService:
             if status in {"partially_filled", "filled", "canceled", "rejected"}:
                 await self.reconcile()
 
+    async def _poll_open_orders_broker(self) -> None:
+        """Generic broker-based order polling (Kraken + Paper)."""
+        for order in self.repo.list_open_orders(self.mode):
+            order_id = order.get("id", "")
+            try:
+                fills = await self.broker.get_fills(order_id)
+                for fill in fills:
+                    self.repo.upsert_fill(
+                        {
+                            "order_id": order_id,
+                            "fill_id": fill.get("fill_id", fill.get("id", "")),
+                            "symbol": order.get("symbol"),
+                            "side": order.get("side"),
+                            "qty": float(fill.get("qty", 0)),
+                            "price": float(fill.get("price", 0)),
+                            "fee": float(fill.get("fee", 0)),
+                            "fee_currency": fill.get("fee_currency", "USD"),
+                            "executed_at": fill.get("executed_at"),
+                            "mode": self.mode,
+                        }
+                    )
+                # Check if order should be marked as terminal
+                broker_orders = await self.broker.get_open_orders()
+                broker_order_ids = {o.get("id", o.get("order_id", "")) for o in broker_orders}
+                if order_id not in broker_order_ids:
+                    current_status = order.get("status", "submitted")
+                    if current_status in ("submitted", "open", "partially_filled"):
+                        self.repo.update_order_status(order_id, "filled", {})
+            except NotImplementedError:
+                pass  # broker doesn't support get_fills; skip
+
     def get_health(self, reason_override: str = "") -> HealthState:
         daily_notional = self.repo.get_daily_notional(date.today(), self.mode)
+        status = "DEGRADED" if self._degraded else "LIVE"
+        if self.circuit_breaker and self.circuit_breaker.is_open:
+            status = "CIRCUIT_OPEN"
         return HealthState(
-            status="DEGRADED" if self._degraded else "LIVE",
+            status=status,
             reason=reason_override,
             last_reconcile_at=self._last_reconcile_at,
             daily_notional_used=daily_notional,
@@ -282,14 +422,28 @@ class CryptoTraderService:
         await self.poll_open_orders()
         await self.reconcile()
 
+    # ── Heartbeats & PnL ──
+
     def _write_heartbeats(self, health: HealthState) -> None:
         now_iso = datetime.now(timezone.utc).isoformat()
+        broker_name = self.cfg.broker_type
         components = [
-            ("robinhood_api", "ok" if not self._degraded else "warning"),
-            ("reconciliation_engine", "ok" if health.status == "LIVE" else "warning"),
+            (f"{broker_name}_api", "ok" if not self._degraded else "warning"),
+            ("reconciliation_engine", "ok" if health.status not in ("DEGRADED", "CIRCUIT_OPEN") else "warning"),
             ("snapshot_store", "ok"),
             ("discord_control", "ok"),
         ]
+        # Add WS-specific heartbeats when using Kraken
+        if self.ws_manager:
+            ws_status = "ok" if self.ws_manager.connected else "error"
+            components.append(("kraken_ws_public", ws_status))
+        if self.ws_private:
+            ws_status = "ok" if self.ws_private.connected else "error"
+            components.append(("kraken_ws_private", ws_status))
+        if self.circuit_breaker:
+            cb_status = "ok" if self.circuit_breaker.allows_trading else "warning"
+            components.append(("circuit_breaker", cb_status))
+
         for component, status in components:
             try:
                 self.repo.upsert_health_heartbeat({
@@ -304,6 +458,20 @@ class CryptoTraderService:
                 pass
 
     def _write_pnl_snapshot(self, equity: float) -> None:
+        """Write P&L snapshot — uses PnlService when available."""
+        if self.pnl_service and self.market_data:
+            try:
+                focus_prices = {
+                    s.symbol: s.mid
+                    for s in self.market_data.get_all_focus_snapshots().values()
+                    if s.mid > 0
+                }
+                self.pnl_service.compute_and_write(equity, focus_prices)
+                return
+            except Exception as e:
+                logger.warning("PnlService snapshot failed, falling back: %s", e)
+
+        # Fallback: simple PnL write (legacy path)
         realized = self.repo.get_realized_pnl(self.mode)
         try:
             self.repo.upsert_pnl_daily({
@@ -337,16 +505,23 @@ class CryptoTraderService:
         except Exception:
             pass
 
+    # ── Positions ──
+
     def _get_open_positions(self) -> set[str]:
         """Get set of symbols with open positions."""
         holdings = (self.repo.latest_holdings_snapshot(self.mode) or {}).get("holdings", {})
         return {sym for sym, qty in holdings.items() if float(qty) > 0}
 
+    # ── Scan / Signal pipeline ──
+
     async def _run_scan(self) -> None:
         """Full pipeline: scan -> score -> signal -> (optional) auto-execute."""
         try:
             # Phase 1: Scan — fetch prices, update cache, score (with chart analysis)
-            candidates = await scan_candidates(self.client, self.price_cache, self.candle_manager)
+            if self._rh_client:
+                candidates = await scan_candidates(self._rh_client, self.price_cache, self.candle_manager)
+            else:
+                candidates = await scan_candidates(None, self.price_cache, self.candle_manager)
             if not candidates:
                 return
 
@@ -412,11 +587,7 @@ class CryptoTraderService:
             traceback.print_exc()
 
     async def _execute_signal(self, signal: Signal) -> None:
-        """Execute a single signal — place order if all checks pass.
-
-        In paper mode: simulates by logging + recording the order intent.
-        Guards: paused, safe_mode, degraded, notional limits.
-        """
+        """Execute a single signal — place order if all checks pass."""
         sym = signal.symbol
         action = signal.action
         notional = signal.suggested_notional
@@ -430,6 +601,9 @@ class CryptoTraderService:
             return
         if self._degraded and self.cfg.stop_trading_on_degraded:
             self._write_thought(f"Signal {action} {sym} skipped -- degraded state", thought_type="signal", symbol=sym)
+            return
+        if self.circuit_breaker and self.circuit_breaker.is_open:
+            self._write_thought(f"Signal {action} {sym} skipped -- circuit breaker OPEN", thought_type="signal", symbol=sym)
             return
         if notional <= 0:
             return
@@ -486,30 +660,56 @@ class CryptoTraderService:
 
         # Live execution
         try:
-            order = await self.place_order(
-                initiator_id=self.cfg.admin_user_id,
-                symbol=sym,
-                side=side,
-                notional=notional,
-                order_type="market",
-            )
+            # Compute qty from notional using current mid price
+            mid_price = 0.0
+            if self.market_data:
+                focus_snap = self.market_data.get_focus_snapshot(sym)
+                if focus_snap and focus_snap.mid > 0:
+                    mid_price = focus_snap.mid
+            if mid_price == 0:
+                snap = self.price_cache.snapshot(sym)
+                mid_price = snap.get("mid", 0)
+            if mid_price <= 0:
+                self._write_thought(f"Signal {action} {sym} skipped -- no price available", thought_type="signal", symbol=sym)
+                return
+
+            qty = notional / mid_price
+
+            if self.order_executor:
+                # Kraken path: use intent-based executor
+                result = await self.order_executor.submit_order(
+                    symbol=sym,
+                    side=side,
+                    qty=qty,
+                    limit_price=mid_price,  # limit order at mid
+                    order_type="limit",
+                    strategy=signal.strategy,
+                    reason=signal.reason,
+                )
+            else:
+                # Legacy path: direct place_order
+                result = await self.place_order(
+                    initiator_id=self.cfg.admin_user_id,
+                    symbol=sym,
+                    side=side,
+                    qty=qty,
+                    order_type="market",
+                )
+
             self._write_thought(
-                f"Order placed: {action} {sym} ${notional:.2f} -> {order.get('status', 'submitted')}",
+                f"Order placed: {action} {sym} ${notional:.2f} -> {result.get('status', 'submitted')}",
                 thought_type="order",
                 symbol=sym,
-                metadata={"order_id": order.get("id"), "signal": signal.to_dict()},
+                metadata={"order_id": result.get("id"), "signal": signal.to_dict()},
             )
 
             # Register with exit manager on live BUY
             if action == "BUY":
-                snap = self.price_cache.snapshot(sym)
-                entry_price = snap.get("mid", 0)
-                if entry_price > 0:
-                    self.exit_manager.register_position(
-                        symbol=sym,
-                        entry_price=entry_price,
-                        entry_time=datetime.now(timezone.utc),
-                    )
+                self.exit_manager.register_position(
+                    symbol=sym,
+                    entry_price=mid_price,
+                    entry_time=datetime.now(timezone.utc),
+                )
         except Exception as e:
             self._write_thought(
                 f"Order FAILED: {action} {sym} ${notional:.2f} -- {e}",
@@ -519,12 +719,10 @@ class CryptoTraderService:
             )
             print(f"[ZOE] ORDER FAILED for {sym}: {e}")
 
-    async def _check_exits(self) -> None:
-        """Check all open positions against exit rules every tick.
+    # ── Exit management ──
 
-        This is the critical missing piece: without this, positions drift
-        indefinitely with no stop-loss, no take-profit, no time stop.
-        """
+    async def _check_exits(self) -> None:
+        """Check all open positions against exit rules every tick."""
         try:
             holdings = (self.repo.latest_holdings_snapshot(self.mode) or {}).get("holdings", {})
             open_symbols = {sym for sym, qty in holdings.items() if float(qty) > 0}
@@ -532,12 +730,11 @@ class CryptoTraderService:
             # Register any positions the exit manager doesn't know about
             for sym in open_symbols:
                 if self.exit_manager.get_position_state(sym) is None:
-                    # Recover entry data from recent orders
                     snap = self.price_cache.snapshot(sym)
                     mid = snap.get("mid", 0)
                     self.exit_manager.register_position(
                         symbol=sym,
-                        entry_price=mid,  # best guess if no historical entry
+                        entry_price=mid,
                         entry_time=datetime.now(timezone.utc),
                     )
 
@@ -589,7 +786,6 @@ class CryptoTraderService:
         print(f"[ZOE] EXIT: {exit_signal.reason.value} {symbol} ({exit_signal.pnl_pct:.2%}) -- {exit_signal.details}")
 
         if not self.cfg.live_ready():
-            # Paper mode: log exit but don't place order
             self._write_thought(
                 f"PAPER EXIT {symbol}: {exit_signal.reason.value} (would sell if live)",
                 thought_type="paper_exit",
@@ -608,23 +804,29 @@ class CryptoTraderService:
                 self.exit_manager.unregister_position(symbol)
                 return
 
-            # Determine notional from current price
-            snap = self.price_cache.snapshot(symbol)
-            mid = snap.get("mid", 0)
-            notional = qty * mid if mid > 0 else 0
+            if self.order_executor:
+                result = await self.order_executor.submit_order(
+                    symbol=symbol,
+                    side="sell",
+                    qty=qty,
+                    order_type="market",
+                    strategy="exit",
+                    reason=exit_signal.reason.value,
+                )
+            else:
+                result = await self.place_order(
+                    initiator_id=self.cfg.admin_user_id,
+                    symbol=symbol,
+                    side="sell",
+                    qty=qty,
+                    order_type="market",
+                )
 
-            order = await self.place_order(
-                initiator_id=self.cfg.admin_user_id,
-                symbol=symbol,
-                side="sell",
-                qty=qty,
-                order_type="market",
-            )
             self._write_thought(
-                f"Exit order placed: SELL {symbol} qty={qty} -> {order.get('status', 'submitted')} | reason={exit_signal.reason.value}",
+                f"Exit order placed: SELL {symbol} qty={qty} -> {result.get('status', 'submitted')} | reason={exit_signal.reason.value}",
                 thought_type="exit_order",
                 symbol=symbol,
-                metadata={"order_id": order.get("id"), "exit": exit_signal.to_dict()},
+                metadata={"order_id": result.get("id"), "exit": exit_signal.to_dict()},
             )
             self.exit_manager.unregister_position(symbol)
         except Exception as e:
@@ -636,11 +838,13 @@ class CryptoTraderService:
             )
             print(f"[ZOE] EXIT ORDER FAILED for {symbol}: {e}")
 
+    # ── Agent state ──
+
     def _save_agent_state_snapshot(self) -> None:
         try:
             holdings = (self.repo.latest_holdings_snapshot(self.mode) or {}).get("holdings", {})
             cash_snap = self.repo.latest_cash_snapshot(self.mode) or {}
-            self.repo.save_agent_state(self.mode, "default", {
+            state: dict[str, Any] = {
                 "open_orders": [o["id"] for o in self.repo.list_open_orders(self.mode)],
                 "holdings": holdings,
                 "cash_available": cash_snap.get("cash_available", 0),
@@ -649,27 +853,53 @@ class CryptoTraderService:
                 "paused": self._paused,
                 "degraded": self._degraded,
                 "last_sync_ts": datetime.now(timezone.utc).isoformat(),
-            })
+                "broker_type": self.cfg.broker_type,
+                "market_data_source": self.cfg.market_data_source,
+            }
+            # Add Kraken-specific health info
+            if self.circuit_breaker:
+                state["circuit_breaker"] = self.circuit_breaker.status_dict()
+            if self.ws_manager:
+                state["ws_public_connected"] = self.ws_manager.connected
+                state["ws_public_reconnects"] = self.ws_manager._reconnect_count
+            if self.ws_private:
+                state["ws_private_connected"] = self.ws_private.connected
+                state["ws_private_reconnects"] = self.ws_private._reconnect_count
+            self.repo.save_agent_state(self.mode, "default", state)
         except Exception:
             pass
 
-    async def _tick_price_cache(self) -> None:
-        """Quick price cache update — fetch batch bid/ask and record ticks.
+    # ── Price cache ──
 
-        Runs more frequently than the full scan to build up price history
-        faster. Does NOT score or generate signals (that's _run_scan's job).
+    async def _tick_price_cache(self) -> None:
+        """Quick price cache update.
+
+        Two paths:
+          1. kraken_ws: read from MarketDataService focus buffer (no REST call)
+          2. polling: fetch from RH batch API (legacy)
         """
-        from .scanner import WATCHLIST
-        try:
-            batch = await self.client.get_best_bid_ask_batch(WATCHLIST)
-            for result in batch.get("results", []):
-                symbol = result.get("symbol", "")
-                bid = float(result.get("bid_inclusive_of_sell_spread", result.get("bid_price", 0)))
-                ask = float(result.get("ask_inclusive_of_buy_spread", result.get("ask_price", 0)))
-                if bid > 0 and ask > 0:
-                    self.price_cache.record(symbol, bid, ask)
-        except Exception:
-            pass  # non-critical — full scan will retry
+        if self.cfg.market_data_source == "kraken_ws" and self.market_data:
+            # WS-driven: read from in-memory focus buffer
+            for sym, snap in self.market_data.get_all_focus_snapshots().items():
+                if snap.bid > 0 and snap.ask > 0:
+                    from .symbol_map import to_internal
+                    internal_sym = to_internal(sym)
+                    self.price_cache.record(internal_sym, snap.bid, snap.ask)
+            return
+
+        # Legacy polling path (RH)
+        if self._rh_client:
+            from .scanner import WATCHLIST
+            try:
+                batch = await self._rh_client.get_best_bid_ask_batch(WATCHLIST)
+                for result in batch.get("results", []):
+                    symbol = result.get("symbol", "")
+                    bid = float(result.get("bid_inclusive_of_sell_spread", result.get("bid_price", 0)))
+                    ask = float(result.get("ask_inclusive_of_buy_spread", result.get("ask_price", 0)))
+                    if bid > 0 and ask > 0:
+                        self.price_cache.record(symbol, bid, ask)
+            except Exception:
+                pass  # non-critical — full scan will retry
 
     async def _persist_candles(self) -> None:
         """Persist newly finalized candles to Supabase."""
@@ -703,69 +933,148 @@ class CryptoTraderService:
             return
         try:
             count = await self.candle_manager.load_historical()
-            self._next_historical_refresh = now + 4 * 3600  # 4 hours
+            self._next_historical_refresh = now + 4 * 3600
             print(f"[ZOE] Historical candle refresh: {count} candles loaded")
         except Exception as e:
             print(f"[ZOE] Historical refresh failed: {e}")
             self._next_historical_refresh = now + 600  # retry in 10 min
 
+    # ── Kraken startup / shutdown ──
+
+    async def _start_kraken_services(self) -> None:
+        """Initialize and start Kraken-specific components."""
+        if self.market_data:
+            print("[ZOE] Initializing MarketDataService...")
+            await self.market_data.initialize()
+            await self.market_data.start()
+            print(f"[ZOE] MarketDataService started: focus={len(self.market_data.focus_symbols)} scout={len(self.market_data.scout_symbols)}")
+
+        if self.ws_manager:
+            print("[ZOE] Starting Kraken WS public...")
+            task = asyncio.create_task(self.ws_manager.run())
+            self._background_tasks.append(task)
+
+        if self.ws_private:
+            print("[ZOE] Starting Kraken WS private...")
+            # Wire fill processor to WS private execution events
+            if self.fill_processor:
+                self.ws_private.on_execution(self.fill_processor.handle_execution)
+            task = asyncio.create_task(self.ws_private.run())
+            self._background_tasks.append(task)
+
+        self._write_thought(
+            f"Kraken services started: ws_public={self.ws_manager is not None}, "
+            f"ws_private={self.ws_private is not None}, "
+            f"market_data={self.market_data is not None}",
+            thought_type="health",
+        )
+
+    async def _stop_kraken_services(self) -> None:
+        """Gracefully shut down Kraken-specific components."""
+        for task in self._background_tasks:
+            task.cancel()
+        self._background_tasks.clear()
+
+        if self.market_data:
+            await self.market_data.stop()
+        if self.ws_manager:
+            await self.ws_manager.close()
+        if self.ws_private:
+            await self.ws_private.stop()
+
+    # ── Main loop ──
+
     async def run_forever(self) -> None:
         next_order_poll = 0.0
         next_scan = 0.0
         next_tick = 0.0
+        next_reposition = 0.0
         scan_interval = 300   # full scan + signal pipeline every 5 min
         tick_interval = 60    # price cache tick every 60s (fast history build)
-        print(f"[ZOE] Crypto trader service started (mode={self.mode})")
+        reposition_interval = 60  # repositioner check every 60s
+        print(f"[ZOE] Crypto trader service started (mode={self.mode}, broker={self.cfg.broker_type}, data={self.cfg.market_data_source})")
         print(f"[ZOE] Pipeline: tick={tick_interval}s -> scan={scan_interval}s -> signals -> auto-execute")
 
         self._write_thought(
-            f"Crypto trader service started (mode={self.mode}). "
+            f"Crypto trader service started (mode={self.mode}, broker={self.cfg.broker_type}, "
+            f"data_source={self.cfg.market_data_source}). "
             f"Pipeline: price tick every {tick_interval}s, full scan every {scan_interval}s, signal engine active.",
             thought_type="health",
         )
 
-        while True:
-            now = time.time()
-            self._cycle_count += 1
+        # ── Start Kraken WS services if configured ──
+        if self.cfg.market_data_source == "kraken_ws":
             try:
-                # Fast price tick — build history between scans
-                if now >= next_tick:
-                    await self._tick_price_cache()
-                    next_tick = now + tick_interval
-
-                # Exit checks run EVERY tick — critical for stop-loss/TP
-                await self._check_exits()
-
-                if now >= next_order_poll and not self._paused:
-                    await self.poll_open_orders()
-                    next_order_poll = now + self.cfg.order_poll_interval_seconds
-
-                health = await self.reconcile()
-
-                self._write_heartbeats(health)
-
-                cash_snap = self.repo.latest_cash_snapshot(self.mode)
-                equity = float((cash_snap or {}).get("buying_power", 0))
-                self._write_pnl_snapshot(equity)
-
-                # Full scan + signal pipeline
-                if now >= next_scan:
-                    await self._run_scan()
-                    next_scan = now + scan_interval
-
-                # Persist finalized candles to Supabase
-                await self._persist_candles()
-
-                # Refresh CoinGecko historical data periodically
-                await self._refresh_historical()
-
-                # Save agent state every 5 cycles
-                if self._cycle_count % 5 == 0:
-                    self._save_agent_state_snapshot()
-
+                await self._start_kraken_services()
             except Exception as e:
-                import traceback
-                self.audit.write("crypto_loop_error", error=str(e))
-                print(f"[ZOE] Reconcile loop error: {e}")
-                traceback.print_exc()
-            await asyncio.sleep(self.cfg.reconcile_interval_seconds)
+                print(f"[ZOE] Kraken service startup failed: {e}")
+                self._write_thought(f"Kraken startup failed: {e}", thought_type="error")
+                # Fall back to polling if WS startup fails
+                self.cfg.market_data_source = "polling"
+
+        try:
+            while True:
+                now = time.time()
+                self._cycle_count += 1
+                try:
+                    # Update circuit breaker state
+                    if self.circuit_breaker and self.market_data:
+                        self.circuit_breaker.check(self.market_data)
+
+                    # Fast price tick — build history between scans
+                    if now >= next_tick:
+                        await self._tick_price_cache()
+                        next_tick = now + tick_interval
+
+                    # Exit checks run EVERY tick — critical for stop-loss/TP
+                    await self._check_exits()
+
+                    if now >= next_order_poll and not self._paused:
+                        await self.poll_open_orders()
+                        next_order_poll = now + self.cfg.order_poll_interval_seconds
+
+                    health = await self.reconcile()
+
+                    self._write_heartbeats(health)
+
+                    cash_snap = self.repo.latest_cash_snapshot(self.mode)
+                    equity = float((cash_snap or {}).get("buying_power", 0))
+                    self._write_pnl_snapshot(equity)
+
+                    # Full scan + signal pipeline
+                    if now >= next_scan:
+                        await self._run_scan()
+                        next_scan = now + scan_interval
+
+                    # Repositioner: cancel stale limit orders
+                    if self.repositioner and now >= next_reposition:
+                        try:
+                            cancelled = await self.repositioner.check_and_cancel_stale()
+                            if cancelled:
+                                self._write_thought(
+                                    f"Repositioner cancelled {len(cancelled)} stale orders: {cancelled}",
+                                    thought_type="repositioner",
+                                )
+                        except Exception as e:
+                            logger.warning("Repositioner error: %s", e)
+                        next_reposition = now + reposition_interval
+
+                    # Persist finalized candles to Supabase
+                    await self._persist_candles()
+
+                    # Refresh CoinGecko historical data periodically
+                    await self._refresh_historical()
+
+                    # Save agent state every 5 cycles
+                    if self._cycle_count % 5 == 0:
+                        self._save_agent_state_snapshot()
+
+                except Exception as e:
+                    import traceback
+                    self.audit.write("crypto_loop_error", error=str(e))
+                    print(f"[ZOE] Reconcile loop error: {e}")
+                    traceback.print_exc()
+                await asyncio.sleep(self.cfg.reconcile_interval_seconds)
+        finally:
+            # Graceful shutdown
+            await self._stop_kraken_services()

--- a/zoe-terminal/src/components/BalancesCard.tsx
+++ b/zoe-terminal/src/components/BalancesCard.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import { Wallet } from 'lucide-react';
+import { formatCurrency, cn } from '../lib/utils';
+import type { Database } from '../lib/types';
+
+type FocusSnapshot = Database['public']['Tables']['market_snapshot_focus']['Row'];
+type CryptoPosition = Database['public']['Tables']['crypto_positions']['Row'];
+
+interface BalancesCardProps {
+  cashUsd: number;
+  positions: CryptoPosition[];
+  focusSnapshots: Record<string, FocusSnapshot>;
+  className?: string;
+}
+
+interface AssetRow {
+  asset: string;
+  qty: number;
+  price: number;
+  value: number;
+  allocation: number;
+}
+
+export function BalancesCard({ cashUsd, positions, focusSnapshots, className }: BalancesCardProps) {
+  const { assets, totalValue } = useMemo(() => {
+    const rows: AssetRow[] = [];
+    let cryptoTotal = 0;
+
+    for (const pos of positions) {
+      if (pos.qty <= 0) continue;
+      const snap = focusSnapshots[pos.symbol];
+      const price = snap?.mid ?? 0;
+      const value = pos.qty * price;
+      cryptoTotal += value;
+      rows.push({
+        asset: pos.symbol.replace('/USD', '').replace('-USD', ''),
+        qty: pos.qty,
+        price,
+        value,
+        allocation: 0, // computed below
+      });
+    }
+
+    const total = cashUsd + cryptoTotal;
+
+    // Compute allocations
+    for (const row of rows) {
+      row.allocation = total > 0 ? (row.value / total) * 100 : 0;
+    }
+
+    // Sort by value descending
+    rows.sort((a, b) => b.value - a.value);
+
+    return { assets: rows, totalValue: total };
+  }, [cashUsd, positions, focusSnapshots]);
+
+  const cashAllocation = totalValue > 0 ? (cashUsd / totalValue) * 100 : 100;
+
+  return (
+    <div className={cn('card-premium card-shimmer-sweep p-4 sm:p-6', className)}>
+      <div className="flex items-center justify-between mb-3 sm:mb-4">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted flex items-center gap-2">
+          <Wallet className="w-3 h-3 text-accent" /> Balance Breakdown
+        </h3>
+        <span className="text-[9px] font-bold text-text-dim uppercase tracking-widest">
+          {formatCurrency(totalValue)} total
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        {/* Cash row */}
+        <div className="flex items-center justify-between py-1.5 px-2 bg-background/50 border border-border rounded-lg">
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-black text-accent uppercase tracking-widest">USD</span>
+            <span className="text-[9px] text-text-dim">Cash</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-bold text-white tabular-nums">{formatCurrency(cashUsd)}</span>
+            <span className="text-[9px] text-text-dim tabular-nums w-12 text-right">
+              {cashAllocation.toFixed(1)}%
+            </span>
+          </div>
+        </div>
+
+        {/* Crypto asset rows */}
+        {assets.map((row) => (
+          <div
+            key={row.asset}
+            className="flex items-center justify-between py-1.5 px-2 bg-background/50 border border-border rounded-lg"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] font-black text-white uppercase tracking-widest">{row.asset}</span>
+              <span className="text-[9px] text-text-dim tabular-nums">
+                {row.qty < 1 ? row.qty.toFixed(6) : row.qty.toFixed(4)}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-bold text-white tabular-nums">{formatCurrency(row.value)}</span>
+              <span className="text-[9px] text-text-dim tabular-nums w-12 text-right">
+                {row.allocation.toFixed(1)}%
+              </span>
+            </div>
+          </div>
+        ))}
+
+        {assets.length === 0 && (
+          <p className="text-[9px] text-text-dim text-center py-2">No crypto holdings</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/zoe-terminal/src/components/FeesSummary.tsx
+++ b/zoe-terminal/src/components/FeesSummary.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Receipt } from 'lucide-react';
+import { formatCurrency, cn } from '../lib/utils';
+import { supabase, supabaseMisconfigured } from '../lib/supabaseClient';
+import { useModeContext } from '../lib/mode';
+
+interface FeeBucket {
+  label: string;
+  amount: number;
+}
+
+interface FeesSummaryProps {
+  className?: string;
+}
+
+export function FeesSummary({ className }: FeesSummaryProps) {
+  const { mode } = useModeContext();
+  const [buckets, setBuckets] = useState<FeeBucket[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFees = useCallback(async () => {
+    if (supabaseMisconfigured) return;
+    try {
+      const now = new Date();
+      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+      const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+      const [todayRes, weekRes, monthRes, allRes] = await Promise.all([
+        supabase
+          .from('fee_ledger')
+          .select('fee_usd')
+          .eq('mode', mode)
+          .gte('created_at', todayStart),
+        supabase
+          .from('fee_ledger')
+          .select('fee_usd')
+          .eq('mode', mode)
+          .gte('created_at', weekAgo),
+        supabase
+          .from('fee_ledger')
+          .select('fee_usd')
+          .eq('mode', mode)
+          .gte('created_at', monthAgo),
+        supabase
+          .from('fee_ledger')
+          .select('fee_usd')
+          .eq('mode', mode),
+      ]);
+
+      const sum = (rows: { fee_usd: number }[] | null) =>
+        (rows ?? []).reduce((s, r) => s + (r.fee_usd ?? 0), 0);
+
+      setBuckets([
+        { label: 'Today', amount: sum(todayRes.data as any) },
+        { label: '7d', amount: sum(weekRes.data as any) },
+        { label: '30d', amount: sum(monthRes.data as any) },
+        { label: 'All Time', amount: sum(allRes.data as any) },
+      ]);
+    } catch (err) {
+      console.error('FeesSummary fetch error:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    fetchFees();
+    const interval = setInterval(fetchFees, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchFees]);
+
+  if (loading) return null;
+
+  const allTimeFees = buckets.find(b => b.label === 'All Time')?.amount ?? 0;
+  if (allTimeFees === 0 && buckets.every(b => b.amount === 0)) return null;
+
+  return (
+    <div className={cn('card-premium card-shimmer-sweep p-4 sm:p-6', className)}>
+      <div className="flex items-center justify-between mb-3 sm:mb-4">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted flex items-center gap-2">
+          <Receipt className="w-3 h-3 text-warning" /> Trading Fees
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2">
+        {buckets.map((b) => (
+          <div key={b.label} className="text-center py-2 px-1 bg-background/50 border border-border rounded-lg">
+            <p className="text-[9px] font-bold text-text-dim uppercase tracking-widest mb-1">{b.label}</p>
+            <p className="text-xs font-bold text-warning tabular-nums">{formatCurrency(b.amount)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/zoe-terminal/src/hooks/useMarketSnapshots.ts
+++ b/zoe-terminal/src/hooks/useMarketSnapshots.ts
@@ -1,0 +1,113 @@
+/**
+ * useMarketSnapshots — Realtime subscription on market_snapshot_focus
+ * for sub-second live price updates in the dashboard.
+ *
+ * Falls back to polling every 2s if realtime channel fails.
+ * Returns a map of symbol → snapshot row.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { supabase, supabaseMisconfigured } from "../lib/supabaseClient";
+import type { Database } from "../lib/types";
+
+type FocusSnapshot = Database["public"]["Tables"]["market_snapshot_focus"]["Row"];
+
+export interface MarketSnapshotsResult {
+  /** Map of symbol → latest focus snapshot */
+  snapshots: Record<string, FocusSnapshot>;
+  /** Flat array of all snapshots, sorted by symbol */
+  snapshotsList: FocusSnapshot[];
+  /** Whether the initial load is in progress */
+  loading: boolean;
+  /** Last update timestamp (ISO string) from the most recent snapshot */
+  lastUpdated: string | null;
+}
+
+const FALLBACK_POLL_MS = 2_000;
+
+export function useMarketSnapshots(): MarketSnapshotsResult {
+  const [snapshots, setSnapshots] = useState<Record<string, FocusSnapshot>>({});
+  const [loading, setLoading] = useState(true);
+  const realtimeActive = useRef(false);
+
+  // Full fetch from market_snapshot_focus
+  const fetchAll = useCallback(async () => {
+    if (supabaseMisconfigured) return;
+    try {
+      const { data, error } = await supabase
+        .from("market_snapshot_focus")
+        .select("*")
+        .order("symbol", { ascending: true });
+
+      if (error) {
+        console.error("market_snapshot_focus fetch error:", error.message);
+        return;
+      }
+      if (data) {
+        const map: Record<string, FocusSnapshot> = {};
+        for (const row of data as FocusSnapshot[]) {
+          map[row.symbol] = row;
+        }
+        setSnapshots(map);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial fetch
+    fetchAll();
+
+    // Realtime subscription for INSERT/UPDATE on market_snapshot_focus
+    const channel = supabase
+      .channel("market-snapshots-focus-rt")
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "market_snapshot_focus",
+        },
+        (payload) => {
+          realtimeActive.current = true;
+          const row = payload.new as FocusSnapshot;
+          if (row && row.symbol) {
+            setSnapshots((prev) => ({ ...prev, [row.symbol]: row }));
+          }
+        }
+      )
+      .subscribe((status) => {
+        if (status === "SUBSCRIBED") {
+          realtimeActive.current = true;
+        }
+      });
+
+    // Fallback polling in case realtime doesn't fire
+    const pollInterval = setInterval(() => {
+      if (!realtimeActive.current) {
+        fetchAll();
+      }
+      // Reset flag — if realtime is working it'll set it back to true
+      realtimeActive.current = false;
+    }, FALLBACK_POLL_MS);
+
+    return () => {
+      clearInterval(pollInterval);
+      supabase.removeChannel(channel);
+    };
+  }, [fetchAll]);
+
+  // Derived: sorted list + last updated
+  const snapshotsList = Object.values(snapshots).sort((a, b) =>
+    a.symbol.localeCompare(b.symbol)
+  );
+  const lastUpdated =
+    snapshotsList.length > 0
+      ? snapshotsList.reduce((latest, s) =>
+          s.updated_at > latest.updated_at ? s : latest
+        ).updated_at
+      : null;
+
+  return { snapshots, snapshotsList, loading, lastUpdated };
+}

--- a/zoe-terminal/src/lib/types.ts
+++ b/zoe-terminal/src/lib/types.ts
@@ -178,7 +178,7 @@ export interface Database {
           taken_at: string;
           holdings: Json;
           total_crypto_value: number;
-          source: "robinhood";
+          source: "robinhood" | "kraken";
           mode: "paper" | "live";
         };
       };
@@ -188,7 +188,7 @@ export interface Database {
           taken_at: string;
           cash_available: number;
           buying_power: number;
-          source: "robinhood";
+          source: "robinhood" | "kraken";
           mode: "paper" | "live";
         };
       };
@@ -197,14 +197,99 @@ export interface Database {
           id: string;
           taken_at: string;
           local_cash: number;
-          rh_cash: number;
+          broker_cash: number;
           cash_diff: number;
           local_holdings: Json;
-          rh_holdings: Json;
+          broker_holdings: Json;
           holdings_diff: Json;
           status: "ok" | "degraded";
           reason: string | null;
           mode: "paper" | "live";
+        };
+      };
+      market_catalog: {
+        Row: {
+          symbol: string;
+          base_asset: string;
+          quote_asset: string;
+          lot_decimals: number;
+          pair_decimals: number;
+          lot_min: number;
+          cost_min: number;
+          tick_size: number | null;
+          status: string;
+          ordermin: number | null;
+          updated_at: string;
+        };
+      };
+      market_snapshot_focus: {
+        Row: {
+          symbol: string;
+          bid: number | null;
+          ask: number | null;
+          mid: number | null;
+          last_price: number | null;
+          volume_24h: number | null;
+          change_pct_24h: number | null;
+          spread_bps: number | null;
+          updated_at: string;
+        };
+      };
+      market_snapshot_scout: {
+        Row: {
+          symbol: string;
+          mid: number | null;
+          volume_24h: number | null;
+          change_pct_24h: number | null;
+          updated_at: string;
+        };
+      };
+      order_intents: {
+        Row: {
+          intent_id: string;
+          symbol: string;
+          side: "buy" | "sell";
+          qty: number;
+          limit_price: number | null;
+          order_type: string;
+          strategy: string | null;
+          reason: string | null;
+          status: "pending" | "submitted" | "filled" | "partially_filled" | "cancelled" | "rejected" | "expired";
+          client_order_id: string | null;
+          submitted_at: string | null;
+          resolved_at: string | null;
+          mode: "paper" | "live";
+          created_at: string;
+        };
+      };
+      crypto_positions: {
+        Row: {
+          symbol: string;
+          qty: number;
+          avg_cost: number;
+          mode: "paper" | "live";
+          updated_at: string;
+        };
+      };
+      fee_ledger: {
+        Row: {
+          id: string;
+          fill_id: string;
+          symbol: string;
+          fee: number;
+          fee_currency: string;
+          fee_usd: number;
+          mode: "paper" | "live";
+          created_at: string;
+        };
+      };
+      trade_locks: {
+        Row: {
+          symbol: string;
+          mode: string;
+          locked_by: string;
+          locked_at: string;
+          expires_at: string;
         };
       };
       daily_notional: {


### PR DESCRIPTION
## Summary
- **Multi-broker architecture**: Adds `Broker` ABC with factory pattern supporting paper, Robinhood (legacy), and Kraken Pro backends, all selectable via `BROKER_TYPE` env var
- **Kraken full integration**: REST client (HMAC-SHA512), WS v2 public + private feeds, Scout/Focus two-tier market data (500ms/10s flush), order intent pipeline with idempotent placement, fill processor with weighted average cost, P&L service, circuit breaker, repositioner, rate limiter, and symbol normalization
- **Dashboard updates**: Live prices now prefer `market_snapshot_focus` (Kraken WS) with automatic fallback to legacy `candidate_scans`; positions table reads `avg_cost` from new `crypto_positions` table; equity chart adds gross/net P&L toggle; new `BalancesCard`, `FeesSummary`, and `useMarketSnapshots` realtime hook
- **Safety first**: Defaults to `BROKER_TYPE=paper` with triple-gate for live trading; all changes behind feature flags; 3 SQL migrations for new tables

### New files (20)
| Category | Files |
|----------|-------|
| Backend core | `broker_factory.py`, `kraken_broker.py`, `kraken_client.py`, `symbol_map.py` |
| Market data | `market_data_service.py`, `kraken_ws_manager.py`, `kraken_ws_private.py` |
| Order engine | `order_executor.py`, `fill_processor.py`, `repositioner.py` |
| Accounting | `pnl_service.py` |
| Safety | `rate_limiter.py`, `circuit_breaker.py`, `test_connectivity.py` |
| Migrations | `20260214_kraken_market_data.sql`, `20260215_kraken_order_engine.sql`, `20260216_kraken_accounting.sql` |
| Dashboard | `useMarketSnapshots.ts`, `BalancesCard.tsx`, `FeesSummary.tsx` |

### Modified files (12)
`trader.py`, `__main__.py`, `clawdbot.py`, `broker.py`, `config.py`, `supabase_repository.py`, `.env.example`, `types.ts`, `useDashboardData.ts`, `Overview.tsx`, `PositionsTable.tsx`, `EquityChart.tsx`

## Test plan
- [ ] Verify `BROKER_TYPE=paper` (default) — bot starts, paper trades execute with Kraken fee simulation
- [ ] Verify `BROKER_TYPE=robinhood` — existing RH flow unchanged, legacy polling works
- [ ] Verify `BROKER_TYPE=kraken` with `MARKET_DATA_SOURCE=kraken_ws` — WS connects, focus/scout data flows
- [ ] Run `python -m services.crypto_trader.test_connectivity` to smoke-test Kraken REST/WS
- [ ] Verify dashboard loads with no Kraken data (graceful fallback to candidate_scans)
- [ ] Verify dashboard loads with market_snapshot_focus data (live prices show "KRAKEN WS" badge)
- [ ] Verify equity chart gross/net toggle appears when gross_equity data exists
- [ ] Run SQL migrations against Supabase in order (market data → order engine → accounting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)