### PR TITLE
feat: replace Robinhood with Kraken exchange integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,17 @@ TWILIO_AUTH_TOKEN=your_auth_token_here
 # Must be a WhatsApp-enabled Twilio number, prefixed with whatsapp:
 TWILIO_WHATSAPP_FROM=whatsapp:+17343367101
 
-# Robinhood crypto live-trading defaults (safe by default).
+# ── Exchange Selection ──────────────────────────────────────
+CRYPTO_EXCHANGE=kraken
+
+# ── Kraken (Primary Exchange) ──────────────────────────────
+KRAKEN_API_KEY=
+KRAKEN_API_SECRET=
+KRAKEN_USE_WEBSOCKET=true
+LIVE_TRADING=false
+LIVE_CONFIRM=
+
+# ── Robinhood (Legacy — Optional) ──────────────────────────
 RH_CRYPTO_API_KEY=
 RH_CRYPTO_PRIVATE_KEY_SEED=
 RH_CRYPTO_BASE_URL=https://trading.robinhood.com

--- a/integrations/kraken_client/__init__.py
+++ b/integrations/kraken_client/__init__.py
@@ -1,0 +1,5 @@
+from .client import KrakenClient, KrakenConfig
+from .usd_converter import USDConverter
+from .websocket import KrakenWebSocket
+
+__all__ = ["KrakenClient", "KrakenConfig", "USDConverter", "KrakenWebSocket"]

--- a/integrations/kraken_client/client.py
+++ b/integrations/kraken_client/client.py
@@ -1,0 +1,410 @@
+"""Kraken REST API client with HMAC-SHA512 authentication.
+
+Handles all private/public API calls, rate limiting, and Kraken-specific
+asset/pair name normalization.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+
+
+# ── Kraken asset name normalization ──────────────────────────────────────────
+# Kraken uses legacy prefixed names: XXBT=BTC, XETH=ETH, ZUSD=USD, etc.
+# Modern assets (SOL, DOT, MATIC) have no prefix.
+
+_ASSET_MAP: dict[str, str] = {
+    "XXBT": "BTC",
+    "XBT": "BTC",
+    "XETH": "ETH",
+    "XXRP": "XRP",
+    "XLTC": "LTC",
+    "XXLM": "XLM",
+    "XXDG": "DOGE",
+    "XZEC": "ZEC",
+    "XXMR": "XMR",
+    "XREP": "REP",
+    "XETC": "ETC",
+    "ZUSD": "USD",
+    "ZEUR": "EUR",
+    "ZGBP": "GBP",
+    "ZJPY": "JPY",
+    "ZCAD": "CAD",
+    "ZAUD": "AUD",
+    "ZKRW": "KRW",
+}
+
+# Reverse map for building Kraken pair names
+_ASSET_TO_KRAKEN: dict[str, str] = {v: k for k, v in _ASSET_MAP.items()}
+_ASSET_TO_KRAKEN["BTC"] = "XBT"  # Kraken uses XBT in pairs
+
+
+def normalize_asset(name: str) -> str:
+    """Convert Kraken asset name to standard symbol: XXBT → BTC, ZUSD → USD."""
+    # Strip staking suffix
+    base = name.rstrip(".S").rstrip(".M").rstrip(".P")
+    if base in _ASSET_MAP:
+        return _ASSET_MAP[base]
+    # Strip single X/Z prefix for older assets
+    if len(base) == 4 and base[0] in ("X", "Z") and base not in _ASSET_MAP:
+        candidate = base[1:]
+        if candidate.isalpha():
+            return candidate
+    return base
+
+
+def normalize_pair(kraken_pair: str) -> str:
+    """Convert Kraken pair to standard format: XXBTZUSD → BTC-USD."""
+    # Try known patterns
+    for suffix_k, suffix_n in [("ZUSD", "USD"), ("USD", "USD"), ("ZUSDT", "USDT"), ("USDT", "USDT")]:
+        if kraken_pair.endswith(suffix_k):
+            base_k = kraken_pair[: -len(suffix_k)]
+            base_n = normalize_asset(base_k)
+            return f"{base_n}-{suffix_n}"
+    # Fallback: split at common quote currencies
+    for quote in ("USD", "USDT", "EUR", "XBT", "BTC", "ETH"):
+        if kraken_pair.endswith(quote):
+            base_k = kraken_pair[: -len(quote)]
+            base_n = normalize_asset(base_k)
+            quote_n = normalize_asset(quote) if quote in _ASSET_MAP else quote
+            return f"{base_n}-{quote_n}"
+    return kraken_pair
+
+
+def denormalize_pair(standard_pair: str) -> str:
+    """Convert BTC-USD → XBTUSD for Kraken API calls."""
+    parts = standard_pair.split("-")
+    if len(parts) != 2:
+        return standard_pair
+    base, quote = parts
+    k_base = _ASSET_TO_KRAKEN.get(base, base)
+    k_quote = _ASSET_TO_KRAKEN.get(quote, quote)
+    return f"{k_base}{k_quote}"
+
+
+# ── Rate limiter ─────────────────────────────────────────────────────────────
+
+class _RateLimiter:
+    """Token bucket rate limiter for Kraken API (Intermediate tier)."""
+
+    def __init__(self, capacity: int = 15, decay_rate: float = 0.33):
+        self.capacity = capacity
+        self.decay_rate = decay_rate
+        self.tokens = float(capacity)
+        self._last = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, cost: int = 1) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last
+            self.tokens = min(self.capacity, self.tokens + elapsed * self.decay_rate)
+            self._last = now
+            if self.tokens < cost:
+                wait = (cost - self.tokens) / self.decay_rate
+                await asyncio.sleep(wait)
+                self.tokens = cost
+            self.tokens -= cost
+
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+@dataclass
+class KrakenConfig:
+    api_key: str = ""
+    api_secret: str = ""  # base64-encoded
+    base_url: str = "https://api.kraken.com"
+    api_version: str = "0"
+    timeout: float = 30.0
+    max_retries: int = 3
+
+    @classmethod
+    def from_env(cls) -> KrakenConfig:
+        return cls(
+            api_key=os.getenv("KRAKEN_API_KEY", ""),
+            api_secret=os.getenv("KRAKEN_API_SECRET", ""),
+        )
+
+
+# ── Client ───────────────────────────────────────────────────────────────────
+
+class KrakenError(Exception):
+    """Raised when Kraken API returns an error."""
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__(f"Kraken API error: {'; '.join(errors)}")
+
+
+class KrakenClient:
+    """Async Kraken REST API client."""
+
+    def __init__(self, config: KrakenConfig | None = None):
+        self.cfg = config or KrakenConfig.from_env()
+        self._session: aiohttp.ClientSession | None = None
+        self._rate = _RateLimiter()
+        self._secret_bytes = base64.b64decode(self.cfg.api_secret) if self.cfg.api_secret else b""
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self.cfg.timeout)
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    # ── Auth ─────────────────────────────────────────────────────────────
+
+    def _sign(self, url_path: str, data: dict[str, Any]) -> dict[str, str]:
+        """Generate Kraken API-Sign header.
+
+        signature = HMAC-SHA512(
+            url_path + SHA256(nonce + post_data),
+            base64_decode(api_secret)
+        )
+        """
+        nonce = data["nonce"]
+        post_data = urllib.parse.urlencode(data)
+        encoded = (str(nonce) + post_data).encode("utf-8")
+        message = url_path.encode("utf-8") + hashlib.sha256(encoded).digest()
+        signature = hmac.new(self._secret_bytes, message, hashlib.sha512)
+        sig_b64 = base64.b64encode(signature.digest()).decode("utf-8")
+        return {
+            "API-Key": self.cfg.api_key,
+            "API-Sign": sig_b64,
+        }
+
+    # ── Low-level request methods ────────────────────────────────────────
+
+    async def _public(self, endpoint: str, params: dict[str, Any] | None = None) -> Any:
+        """GET /0/public/{endpoint}"""
+        url = f"{self.cfg.base_url}/{self.cfg.api_version}/public/{endpoint}"
+        await self._rate.acquire(cost=1)
+        session = await self._get_session()
+        for attempt in range(self.cfg.max_retries):
+            try:
+                async with session.get(url, params=params) as resp:
+                    body = await resp.json()
+                    if body.get("error"):
+                        raise KrakenError(body["error"])
+                    return body.get("result", {})
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                if attempt == self.cfg.max_retries - 1:
+                    raise
+                await asyncio.sleep(2 ** attempt)
+
+    async def _private(self, endpoint: str, data: dict[str, Any] | None = None) -> Any:
+        """POST /0/private/{endpoint} with authentication."""
+        url_path = f"/{self.cfg.api_version}/private/{endpoint}"
+        url = f"{self.cfg.base_url}{url_path}"
+        if data is None:
+            data = {}
+        data["nonce"] = str(int(time.time() * 1000))
+        headers = self._sign(url_path, data)
+        await self._rate.acquire(cost=1)
+        session = await self._get_session()
+        for attempt in range(self.cfg.max_retries):
+            try:
+                async with session.post(url, data=data, headers=headers) as resp:
+                    body = await resp.json()
+                    if body.get("error"):
+                        errors = body["error"]
+                        # Rate limit errors → back off
+                        if any("EAPI:Rate limit" in e for e in errors):
+                            wait = 2 ** (attempt + 1)
+                            print(f"[KRAKEN] Rate limited, waiting {wait}s")
+                            await asyncio.sleep(wait)
+                            # Re-generate nonce for retry
+                            data["nonce"] = str(int(time.time() * 1000))
+                            headers = self._sign(url_path, data)
+                            continue
+                        raise KrakenError(errors)
+                    return body.get("result", {})
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                if attempt == self.cfg.max_retries - 1:
+                    raise
+                await asyncio.sleep(2 ** attempt)
+                # Re-generate nonce for retry
+                data["nonce"] = str(int(time.time() * 1000))
+                headers = self._sign(url_path, data)
+
+    # ── Public endpoints ─────────────────────────────────────────────────
+
+    async def get_ticker(self, pairs: list[str]) -> dict[str, Any]:
+        """Get ticker info for one or more pairs.
+
+        Args:
+            pairs: List of Kraken pair names (e.g., ["XBTUSD", "ETHUSD"])
+
+        Returns:
+            Dict mapping pair → ticker data with keys:
+            a=[ask price, whole lot volume, lot volume]
+            b=[bid price, whole lot volume, lot volume]
+            c=[last trade closed price, lot volume]
+            v=[volume today, last 24h]
+            p=[vwap today, last 24h]
+            t=[number of trades today, last 24h]
+            l=[low today, last 24h]
+            h=[high today, last 24h]
+            o=today's opening price
+        """
+        return await self._public("Ticker", {"pair": ",".join(pairs)})
+
+    async def get_asset_pairs(self, pairs: list[str] | None = None) -> dict[str, Any]:
+        """Get tradeable asset pairs metadata."""
+        params = {}
+        if pairs:
+            params["pair"] = ",".join(pairs)
+        return await self._public("AssetPairs", params or None)
+
+    async def get_system_status(self) -> dict[str, Any]:
+        """Get Kraken system status."""
+        return await self._public("SystemStatus")
+
+    # ── Private endpoints ────────────────────────────────────────────────
+
+    async def get_account_balance(self) -> dict[str, float]:
+        """Get all asset balances.
+
+        Returns:
+            Dict mapping Kraken asset name → balance (e.g., {"XXBT": 0.5, "ZUSD": 1234.56})
+        """
+        raw = await self._private("Balance")
+        return {k: float(v) for k, v in raw.items()}
+
+    async def get_trade_balance(self, asset: str = "ZUSD") -> dict[str, Any]:
+        """Get trade balance summary denominated in given asset.
+
+        Returns dict with keys: eb (equivalent balance), tb (trade balance),
+        m (margin), n (unrealized P&L), e (equity), mf (free margin), etc.
+        """
+        return await self._private("TradeBalance", {"asset": asset})
+
+    async def get_open_orders(self) -> dict[str, Any]:
+        """Get all open orders.
+
+        Returns:
+            {"open": {txid: order_data, ...}}
+        """
+        return await self._private("OpenOrders")
+
+    async def get_closed_orders(self, start: int | None = None, end: int | None = None) -> dict[str, Any]:
+        """Get closed orders."""
+        data: dict[str, Any] = {}
+        if start is not None:
+            data["start"] = start
+        if end is not None:
+            data["end"] = end
+        return await self._private("ClosedOrders", data)
+
+    async def get_trades_history(self, start: int | None = None, end: int | None = None) -> dict[str, Any]:
+        """Get trade history (fills)."""
+        data: dict[str, Any] = {}
+        if start is not None:
+            data["start"] = start
+        if end is not None:
+            data["end"] = end
+        return await self._private("TradesHistory", data)
+
+    async def query_orders(self, txids: list[str]) -> dict[str, Any]:
+        """Query specific orders by txid."""
+        return await self._private("QueryOrders", {"txid": ",".join(txids)})
+
+    async def get_ws_token(self) -> str:
+        """Get WebSocket authentication token (valid ~15 min)."""
+        result = await self._private("GetWebSocketsToken")
+        return result["token"]
+
+    async def place_order(
+        self,
+        pair: str,
+        side: str,
+        ordertype: str,
+        volume: float,
+        price: float | None = None,
+        validate: bool = False,
+    ) -> dict[str, Any]:
+        """Place an order.
+
+        Args:
+            pair: Kraken pair name (e.g., "XBTUSD")
+            side: "buy" or "sell"
+            ordertype: "market", "limit", "stop-loss", "take-profit", etc.
+            volume: Order volume in base currency
+            price: Limit price (required for limit orders)
+            validate: If True, validate only (don't actually submit)
+
+        Returns:
+            {"descr": {"order": "..."}, "txid": ["OXXXX-XXXXX-XXXXXX"]}
+        """
+        data: dict[str, Any] = {
+            "pair": pair,
+            "type": side,
+            "ordertype": ordertype,
+            "volume": str(volume),
+        }
+        if price is not None:
+            data["price"] = str(price)
+        if validate:
+            data["validate"] = "true"
+        return await self._private("AddOrder", data)
+
+    async def cancel_order(self, txid: str) -> dict[str, Any]:
+        """Cancel an open order."""
+        return await self._private("CancelOrder", {"txid": txid})
+
+    # ── Convenience methods ──────────────────────────────────────────────
+
+    async def get_normalized_balances(self) -> dict[str, float]:
+        """Get balances with normalized asset names (BTC, ETH, USD, etc.).
+
+        Filters out zero balances and staking variants.
+        """
+        raw = await self.get_account_balance()
+        result: dict[str, float] = {}
+        for asset, qty in raw.items():
+            if qty <= 0:
+                continue
+            # Skip staked variants — they'll be counted under the base asset
+            if asset.endswith(".S") or asset.endswith(".M") or asset.endswith(".P"):
+                base = normalize_asset(asset)
+                result[base] = result.get(base, 0.0) + qty
+            else:
+                name = normalize_asset(asset)
+                result[name] = result.get(name, 0.0) + qty
+        return result
+
+    async def get_normalized_open_orders(self) -> list[dict[str, Any]]:
+        """Get open orders with normalized pair names and standard fields."""
+        raw = await self.get_open_orders()
+        orders = raw.get("open", {})
+        result = []
+        for txid, order in orders.items():
+            descr = order.get("descr", {})
+            vol = float(order.get("vol", 0))
+            vol_exec = float(order.get("vol_exec", 0))
+            result.append({
+                "order_id": txid,
+                "pair": normalize_pair(descr.get("pair", "")),
+                "side": descr.get("type", ""),
+                "order_type": descr.get("ordertype", ""),
+                "price": float(descr.get("price", 0) or 0),
+                "volume": vol,
+                "filled": vol_exec,
+                "remaining": vol - vol_exec,
+                "status": order.get("status", "open"),
+                "created_at": order.get("opentm", 0),
+                "raw": order,
+            })
+        return result

--- a/integrations/kraken_client/usd_converter.py
+++ b/integrations/kraken_client/usd_converter.py
@@ -1,0 +1,203 @@
+"""Converts any Kraken asset to USD using ticker data with bridging logic.
+
+Conversion cascade:
+  1. Asset is USD → 1:1
+  2. Direct {ASSET}USD pair → use ticker mid-price
+  3. {ASSET}USDT pair → convert via USDT/USD rate
+  4. {ASSET}XBT pair → convert via BTC/USD rate
+  5. Fallback → $0.00 + warning
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .client import KrakenClient
+
+
+@dataclass
+class AssetValue:
+    """USD-converted value for a single asset."""
+    asset: str
+    amount: float
+    price_usd: float
+    value_usd: float
+
+
+class USDConverter:
+    """Converts Kraken balances to USD with caching."""
+
+    CACHE_TTL = 30  # seconds
+
+    # Common Kraken pair names for USD conversion (base → Kraken pair)
+    _DIRECT_USD_PAIRS: dict[str, str] = {
+        "BTC": "XBTUSD",
+        "ETH": "ETHUSD",
+        "XRP": "XRPUSD",
+        "SOL": "SOLUSD",
+        "DOT": "DOTUSD",
+        "ADA": "ADAUSD",
+        "MATIC": "MATICUSD",
+        "AVAX": "AVAXUSD",
+        "LINK": "LINKUSD",
+        "DOGE": "DOGEUSD",
+        "ATOM": "ATOMUSD",
+        "LTC": "LTCUSD",
+        "UNI": "UNIUSD",
+        "SHIB": "SHIBUSD",
+        "XLM": "XLMUSD",
+        "NEAR": "NEARUSD",
+        "ALGO": "ALGOUSD",
+        "FIL": "FILUSD",
+        "APE": "APEUSD",
+        "MANA": "MANAUSD",
+        "SAND": "SANDUSD",
+        "CRV": "CRVUSD",
+        "AAVE": "AAVEUSD",
+        "GRT": "GRTUSD",
+        "USDT": "USDTZUSD",
+        "USDC": "USDCUSD",
+        "DAI": "DAIUSD",
+    }
+
+    def __init__(self, client: KrakenClient):
+        self.client = client
+        self._ticker_cache: dict[str, dict[str, Any]] = {}
+        self._cache_ts: float = 0
+
+    async def _refresh_tickers(self) -> None:
+        """Fetch all relevant tickers and cache them."""
+        now = time.time()
+        if self._ticker_cache and (now - self._cache_ts) < self.CACHE_TTL:
+            return
+
+        # Build list of pairs we need
+        pairs = list(set(self._DIRECT_USD_PAIRS.values()))
+        # Also add USDT/USD for bridge conversions
+        if "USDTZUSD" not in pairs:
+            pairs.append("USDTZUSD")
+
+        try:
+            tickers = await self.client.get_ticker(pairs)
+            self._ticker_cache = tickers
+            self._cache_ts = now
+        except Exception as e:
+            print(f"[USD-CONV] Ticker fetch failed: {e}")
+            # Keep stale cache rather than clearing
+
+    def _mid_price(self, pair_data: dict[str, Any]) -> float:
+        """Extract mid-price from Kraken ticker data."""
+        try:
+            bid = float(pair_data["b"][0])
+            ask = float(pair_data["a"][0])
+            if bid > 0 and ask > 0:
+                return (bid + ask) / 2.0
+            # Fallback: last trade price
+            return float(pair_data["c"][0])
+        except (KeyError, IndexError, ValueError):
+            return 0.0
+
+    def _find_ticker(self, pair_name: str) -> dict[str, Any] | None:
+        """Find ticker data for a pair, handling Kraken's inconsistent naming."""
+        if pair_name in self._ticker_cache:
+            return self._ticker_cache[pair_name]
+        # Kraken sometimes returns pairs with different naming than requested
+        # e.g., request "XBTUSD" but get "XXBTZUSD" in response
+        for key, data in self._ticker_cache.items():
+            # Normalize and compare
+            if pair_name.replace("Z", "").replace("X", "") in key.replace("Z", "").replace("X", ""):
+                return data
+        return None
+
+    async def get_usd_price(self, asset: str) -> float:
+        """Get the USD price for a single asset.
+
+        Returns 0.0 if price cannot be determined (never NaN).
+        """
+        if asset in ("USD", "ZUSD"):
+            return 1.0
+
+        await self._refresh_tickers()
+
+        # 1. Direct USD pair
+        direct_pair = self._DIRECT_USD_PAIRS.get(asset)
+        if direct_pair:
+            ticker = self._find_ticker(direct_pair)
+            if ticker:
+                price = self._mid_price(ticker)
+                if price > 0:
+                    return price
+
+        # 2. Try constructing pair name dynamically
+        for suffix in ["USD", "ZUSD"]:
+            constructed = f"{asset}{suffix}"
+            ticker = self._find_ticker(constructed)
+            if ticker:
+                price = self._mid_price(ticker)
+                if price > 0:
+                    return price
+
+        # 3. USDT bridge
+        for usdt_suffix in ["USDT"]:
+            usdt_pair = f"{asset}{usdt_suffix}"
+            ticker = self._find_ticker(usdt_pair)
+            if ticker:
+                asset_usdt = self._mid_price(ticker)
+                if asset_usdt > 0:
+                    usdt_usd_ticker = self._find_ticker("USDTZUSD")
+                    usdt_rate = self._mid_price(usdt_usd_ticker) if usdt_usd_ticker else 1.0
+                    if usdt_rate > 0:
+                        return asset_usdt * usdt_rate
+
+        # 4. BTC bridge
+        for btc_suffix in ["XBT"]:
+            btc_pair = f"{asset}{btc_suffix}"
+            ticker = self._find_ticker(btc_pair)
+            if ticker:
+                asset_btc = self._mid_price(ticker)
+                if asset_btc > 0:
+                    btc_usd_ticker = self._find_ticker("XBTUSD") or self._find_ticker("XXBTZUSD")
+                    btc_rate = self._mid_price(btc_usd_ticker) if btc_usd_ticker else 0.0
+                    if btc_rate > 0:
+                        return asset_btc * btc_rate
+
+        # 5. Stablecoins that should be ~$1
+        if asset in ("USDT", "USDC", "DAI", "BUSD"):
+            return 1.0
+
+        print(f"[USD-CONV] No USD rate found for {asset}, defaulting to $0")
+        return 0.0
+
+    async def convert_all(self, balances: dict[str, float]) -> list[AssetValue]:
+        """Convert all balances to USD.
+
+        Args:
+            balances: Dict of normalized asset name → amount (e.g., {"BTC": 0.5, "USD": 1000})
+
+        Returns:
+            List of AssetValue with USD prices and values.
+        """
+        await self._refresh_tickers()
+        results: list[AssetValue] = []
+        for asset, amount in balances.items():
+            if amount <= 0:
+                continue
+            price = await self.get_usd_price(asset)
+            results.append(AssetValue(
+                asset=asset,
+                amount=amount,
+                price_usd=price,
+                value_usd=amount * price,
+            ))
+        return results
+
+    async def total_usd(self, balances: dict[str, float]) -> float:
+        """Get total USD value of all balances."""
+        values = await self.convert_all(balances)
+        return sum(v.value_usd for v in values)
+
+    async def btc_price(self) -> float:
+        """Get current BTC/USD price."""
+        return await self.get_usd_price("BTC")

--- a/integrations/kraken_client/websocket.py
+++ b/integrations/kraken_client/websocket.py
@@ -1,0 +1,256 @@
+"""Kraken WebSocket v2 client for live price + order updates.
+
+Public WS (wss://ws.kraken.com/v2):
+  - ticker channel for held asset pairs → updates price cache + candidate_scans
+
+Private WS (wss://ws-auth.kraken.com/v2):
+  - executions channel (fills) → upserts crypto_fills
+  - balances channel → triggers reconciliation
+
+Reconnection: exponential backoff (1s → 60s max), ping every 30s.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Callable, Coroutine
+
+import aiohttp
+
+from .client import KrakenClient, normalize_asset
+
+log = logging.getLogger(__name__)
+
+PUBLIC_WS_URL = "wss://ws.kraken.com/v2"
+PRIVATE_WS_URL = "wss://ws-auth.kraken.com/v2"
+PING_INTERVAL = 30  # seconds
+MIN_RECONNECT_DELAY = 1.0
+MAX_RECONNECT_DELAY = 60.0
+
+
+class KrakenWebSocket:
+    """Manages public + private WebSocket connections to Kraken v2 API."""
+
+    def __init__(
+        self,
+        client: KrakenClient,
+        on_ticker: Callable[[str, dict[str, Any]], Coroutine] | None = None,
+        on_execution: Callable[[dict[str, Any]], Coroutine] | None = None,
+        on_balance: Callable[[dict[str, Any]], Coroutine] | None = None,
+    ):
+        self.client = client
+        self.on_ticker = on_ticker
+        self.on_execution = on_execution
+        self.on_balance = on_balance
+
+        self._public_ws: aiohttp.ClientWebSocketResponse | None = None
+        self._private_ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._running = False
+        self._tasks: list[asyncio.Task] = []
+        self._subscribed_pairs: list[str] = []
+
+    async def start(self, pairs: list[str] | None = None) -> None:
+        """Start WebSocket connections.
+
+        Args:
+            pairs: Kraken pair names to subscribe for public ticker (e.g., ["XBT/USD", "ETH/USD"]).
+                   If None, no public ticker subscription.
+        """
+        if self._running:
+            return
+        self._running = True
+        self._subscribed_pairs = pairs or []
+        self._session = aiohttp.ClientSession()
+
+        if self._subscribed_pairs:
+            self._tasks.append(asyncio.create_task(self._run_public()))
+        if self.on_execution or self.on_balance:
+            self._tasks.append(asyncio.create_task(self._run_private()))
+
+        log.info("[KrakenWS] Started — public=%d pairs, private=%s",
+                 len(self._subscribed_pairs),
+                 "yes" if (self.on_execution or self.on_balance) else "no")
+
+    async def stop(self) -> None:
+        """Gracefully shut down all WebSocket connections."""
+        self._running = False
+        for task in self._tasks:
+            task.cancel()
+        self._tasks.clear()
+        if self._public_ws and not self._public_ws.closed:
+            await self._public_ws.close()
+        if self._private_ws and not self._private_ws.closed:
+            await self._private_ws.close()
+        if self._session and not self._session.closed:
+            await self._session.close()
+        log.info("[KrakenWS] Stopped")
+
+    # ------------------------------------------------------------------
+    # Public WebSocket (ticker)
+    # ------------------------------------------------------------------
+
+    async def _run_public(self) -> None:
+        """Connect and maintain the public WebSocket with reconnection."""
+        delay = MIN_RECONNECT_DELAY
+        while self._running:
+            try:
+                async with self._session.ws_connect(PUBLIC_WS_URL) as ws:  # type: ignore[union-attr]
+                    self._public_ws = ws
+                    delay = MIN_RECONNECT_DELAY
+                    log.info("[KrakenWS] Public connected")
+
+                    # Subscribe to ticker
+                    await ws.send_json({
+                        "method": "subscribe",
+                        "params": {
+                            "channel": "ticker",
+                            "symbol": self._subscribed_pairs,
+                        },
+                    })
+
+                    await self._read_loop(ws, self._handle_public_msg)
+
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                log.warning("[KrakenWS] Public connection error: %s — reconnecting in %.0fs", e, delay)
+
+            if not self._running:
+                return
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, MAX_RECONNECT_DELAY)
+
+    async def _handle_public_msg(self, msg: dict[str, Any]) -> None:
+        """Process a public WebSocket message."""
+        channel = msg.get("channel")
+        if channel == "ticker" and self.on_ticker:
+            data = msg.get("data", [])
+            for tick in data:
+                symbol = tick.get("symbol", "")
+                await self.on_ticker(symbol, tick)
+
+    # ------------------------------------------------------------------
+    # Private WebSocket (executions, balances)
+    # ------------------------------------------------------------------
+
+    async def _run_private(self) -> None:
+        """Connect and maintain the private (auth) WebSocket with reconnection."""
+        delay = MIN_RECONNECT_DELAY
+        while self._running:
+            try:
+                # Get a fresh WS auth token
+                token = await self.client.get_ws_token()
+                if not token:
+                    log.error("[KrakenWS] Failed to get WS auth token — retrying")
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, MAX_RECONNECT_DELAY)
+                    continue
+
+                async with self._session.ws_connect(PRIVATE_WS_URL) as ws:  # type: ignore[union-attr]
+                    self._private_ws = ws
+                    delay = MIN_RECONNECT_DELAY
+                    log.info("[KrakenWS] Private connected")
+
+                    # Subscribe to executions (fills)
+                    if self.on_execution:
+                        await ws.send_json({
+                            "method": "subscribe",
+                            "params": {
+                                "channel": "executions",
+                                "token": token,
+                                "snap_orders": False,
+                                "snap_trades": False,
+                            },
+                        })
+
+                    # Subscribe to balances
+                    if self.on_balance:
+                        await ws.send_json({
+                            "method": "subscribe",
+                            "params": {
+                                "channel": "balances",
+                                "token": token,
+                                "snap_balances": True,
+                            },
+                        })
+
+                    await self._read_loop(ws, self._handle_private_msg)
+
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                log.warning("[KrakenWS] Private connection error: %s — reconnecting in %.0fs", e, delay)
+
+            if not self._running:
+                return
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, MAX_RECONNECT_DELAY)
+
+    async def _handle_private_msg(self, msg: dict[str, Any]) -> None:
+        """Process a private WebSocket message."""
+        channel = msg.get("channel")
+
+        if channel == "executions" and self.on_execution:
+            for trade in msg.get("data", []):
+                await self.on_execution(trade)
+
+        elif channel == "balances" and self.on_balance:
+            await self.on_balance(msg.get("data", {}))
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    async def _read_loop(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        handler: Callable[[dict[str, Any]], Coroutine],
+    ) -> None:
+        """Read messages from a WebSocket, handling pings and dispatching to handler."""
+        last_ping = time.monotonic()
+
+        async for raw in ws:
+            if not self._running:
+                return
+
+            # Send periodic pings
+            now = time.monotonic()
+            if now - last_ping > PING_INTERVAL:
+                await ws.send_json({"method": "ping"})
+                last_ping = now
+
+            if raw.type == aiohttp.WSMsgType.TEXT:
+                try:
+                    msg = json.loads(raw.data)
+                except json.JSONDecodeError:
+                    continue
+
+                # Skip heartbeats and subscription confirmations
+                method = msg.get("method")
+                if method in ("pong", "heartbeat"):
+                    continue
+                if method == "subscribe" and msg.get("success"):
+                    log.info("[KrakenWS] Subscribed: %s", msg.get("result", {}).get("channel"))
+                    continue
+
+                try:
+                    await handler(msg)
+                except Exception as e:
+                    log.error("[KrakenWS] Handler error: %s", e, exc_info=True)
+
+            elif raw.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+
+    def update_pairs(self, pairs: list[str]) -> None:
+        """Update the list of subscribed pairs (takes effect on next reconnect)."""
+        self._subscribed_pairs = pairs
+
+    @property
+    def connected(self) -> bool:
+        """True if at least one WebSocket is open."""
+        pub = self._public_ws and not self._public_ws.closed
+        priv = self._private_ws and not self._private_ws.closed
+        return bool(pub or priv)

--- a/services/.env.example
+++ b/services/.env.example
@@ -21,8 +21,16 @@ DISCORD_TOKEN=your-discord-bot-token
 DISCORD_CHANNEL_ID=your-channel-id
 DISCORD_GUILD_ID=your-guild-id
 
-# ─── Robinhood (Contract Mapping — Optional) ─────────────────────────
-# Used for symbol mapping and UX parity, NOT for real trading.
+# ─── Exchange Selection ────────────────────────────────────────────
+# Which exchange to use for crypto trading: "kraken" (default) or "robinhood"
+CRYPTO_EXCHANGE=kraken
+
+# ─── Kraken (Primary Exchange) ─────────────────────────────────────
+KRAKEN_API_KEY=
+KRAKEN_API_SECRET=
+KRAKEN_USE_WEBSOCKET=true
+
+# ─── Robinhood (Legacy — Optional) ─────────────────────────────────
 ROBINHOOD_USERNAME=
 ROBINHOOD_PASSWORD=
 ROBINHOOD_MFA_SECRET=

--- a/services/crypto_trader/broker.py
+++ b/services/crypto_trader/broker.py
@@ -1,25 +1,127 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from datetime import datetime, timezone
+from typing import Any, Dict, List
 
-from integrations.robinhood_crypto_client import RobinhoodCryptoClient
 from .config import CryptoTraderConfig
+
 
 class Broker(ABC):
     @abstractmethod
     async def get_cash(self) -> float: ...
-    
+
     @abstractmethod
     async def get_positions(self) -> Dict[str, float]: ...
-    
+
+    @abstractmethod
+    async def get_total_usd(self) -> float: ...
+
+    @abstractmethod
+    async def get_open_orders(self) -> List[Dict[str, Any]]: ...
+
     @abstractmethod
     async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]: ...
 
+    async def close(self) -> None:
+        """Clean up resources."""
+        pass
+
+
+class KrakenBroker(Broker):
+    """Live broker backed by Kraken REST API."""
+
+    def __init__(self, client: Any, usd_converter: Any):
+        from integrations.kraken_client import KrakenClient, USDConverter
+        self.client: KrakenClient = client
+        self.usd: USDConverter = usd_converter
+
+    async def get_cash(self) -> float:
+        """Return total fiat (USD + USDT converted to USD)."""
+        balances = await self.client.get_normalized_balances()
+        total_cash = 0.0
+        for asset in ("USD", "USDT", "USDC", "DAI"):
+            qty = balances.get(asset, 0.0)
+            if qty > 0:
+                price = await self.usd.get_usd_price(asset)
+                total_cash += qty * price
+        return total_cash
+
+    async def get_positions(self) -> Dict[str, float]:
+        """Return non-fiat holdings as {symbol-USD: qty}.
+
+        Normalizes to BTC-USD format matching our DB convention.
+        """
+        balances = await self.client.get_normalized_balances()
+        fiat = {"USD", "EUR", "GBP", "JPY", "CAD", "AUD", "KRW", "USDT", "USDC", "DAI"}
+        positions: Dict[str, float] = {}
+        for asset, qty in balances.items():
+            if asset in fiat or qty <= 0:
+                continue
+            symbol = f"{asset}-USD"
+            positions[symbol] = qty
+        return positions
+
+    async def get_total_usd(self) -> float:
+        """Total portfolio value in USD (all assets)."""
+        balances = await self.client.get_normalized_balances()
+        return await self.usd.total_usd(balances)
+
+    async def get_open_orders(self) -> List[Dict[str, Any]]:
+        """Return open orders in normalized format."""
+        return await self.client.get_normalized_open_orders()
+
+    async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]:
+        from integrations.kraken_client.client import denormalize_pair
+        pair = denormalize_pair(symbol)
+        result = await self.client.place_order(
+            pair=pair,
+            side=side,
+            ordertype="limit",
+            volume=qty,
+            price=limit_price,
+        )
+        txid = result.get("txid", [""])[0] if isinstance(result.get("txid"), list) else str(result.get("txid", ""))
+        return {
+            "id": txid,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "limit_price": limit_price,
+            "status": "submitted",
+            "raw": result,
+        }
+
+    async def get_ticker_prices(self, symbols: list[str]) -> Dict[str, float]:
+        """Fetch mid-prices for a list of symbols (BTC-USD format).
+
+        Returns {symbol: mid_price}.
+        """
+        from integrations.kraken_client.client import denormalize_pair
+        pairs = [denormalize_pair(s) for s in symbols]
+        tickers = await self.client.get_ticker(pairs)
+        result: Dict[str, float] = {}
+        for i, symbol in enumerate(symbols):
+            kraken_pair = pairs[i]
+            # Kraken may return with different key
+            for key, data in tickers.items():
+                if kraken_pair in key or key in kraken_pair:
+                    bid = float(data["b"][0])
+                    ask = float(data["a"][0])
+                    result[symbol] = (bid + ask) / 2.0
+                    break
+        return result
+
+    async def close(self) -> None:
+        await self.client.close()
+
+
 class RobinhoodBroker(Broker):
-    def __init__(self, client: RobinhoodCryptoClient):
-        self.client = client
+    def __init__(self, client: Any):
+        from integrations.robinhood_crypto_client import RobinhoodCryptoClient
+        self.client: RobinhoodCryptoClient = client
 
     async def get_cash(self) -> float:
         balances = await self.client.get_account_balances()
@@ -29,14 +131,20 @@ class RobinhoodBroker(Broker):
         holdings_resp = await self.client.get_holdings()
         items = holdings_resp.get("results", [])
         return {
-            item["symbol"]: float(item.get("quantity", 0.0)) 
-            for item in items 
+            item["symbol"]: float(item.get("quantity", 0.0))
+            for item in items
             if float(item.get("quantity", 0.0)) > 0
         }
 
+    async def get_total_usd(self) -> float:
+        # Robinhood doesn't have a single total; approximate from cash + positions value
+        cash = await self.get_cash()
+        return cash  # Positions market value would require price fetches
+
+    async def get_open_orders(self) -> List[Dict[str, Any]]:
+        return []  # Robinhood order polling handled differently
+
     async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]:
-        # Using Limit Orders by default as requested
-        import uuid
         client_oid = f"zoe-prod-{uuid.uuid4()}"
         return await self.client.place_order(
             symbol=symbol,
@@ -47,45 +155,45 @@ class RobinhoodBroker(Broker):
             limit_price=limit_price
         )
 
+    async def close(self) -> None:
+        await self.client.close()
+
+
 class PaperBroker(Broker):
     """Simulates trades with pessimistic fills (Ask for Buy, Bid for Sell)."""
     def __init__(self, market_data_provider: Any, repo: Any):
         self.mdp = market_data_provider
         self.repo = repo
-        self._cash = 2000.0 # Start with $2k paper
+        self._cash = 2000.0
         self._positions: Dict[str, float] = {}
 
     async def get_cash(self) -> float:
-        # In a real paper broker, we'd persist this to DB.
-        # For now, reading from repo or memory.
         return self._cash
 
     async def get_positions(self) -> Dict[str, float]:
         return self._positions
 
+    async def get_total_usd(self) -> float:
+        return self._cash  # Paper mode doesn't track market value
+
+    async def get_open_orders(self) -> List[Dict[str, Any]]:
+        return []
+
     async def place_order(self, symbol: str, side: str, qty: float, limit_price: float) -> Dict[str, Any]:
-        # Validate price against current market to simulate fill probability
         current_price = await self.mdp.get_current_price(symbol)
-        
-        # Slippage/Pessimism
-        # If BUY: limit_price must be >= current_price * 1.001 (0.1% buffer) to fill immediately
-        # If SELL: limit_price must be <= current_price * 0.999
-        
         filled = False
         avg_price = 0.0
-        
+
         if side == "buy":
             if limit_price >= current_price:
                 filled = True
-                avg_price = current_price * 1.001 # Slippage
-        else: # sell
+                avg_price = current_price * 1.001
+        else:
             if limit_price <= current_price:
                 filled = True
-                avg_price = current_price * 0.999 # Slippage
-        
-        import uuid
+                avg_price = current_price * 0.999
+
         order_id = str(uuid.uuid4())
-        
         status = "filled" if filled else "open"
         order = {
             "id": order_id,
@@ -98,9 +206,8 @@ class PaperBroker(Broker):
             "filled_qty": qty if filled else 0,
             "avg_price": avg_price,
         }
-        
+
         if filled:
-            # Update local state
             cost = qty * avg_price
             if side == "buy":
                 if self._cash >= cost:
@@ -117,9 +224,8 @@ class PaperBroker(Broker):
                     order["status"] = "rejected"
                     order["reject_reason"] = "Insufficient position"
 
-            # Log to DB
-            await self.repo.insert_order(order)
-            await self.repo.upsert_fill({
+            self.repo.insert_order(order)
+            self.repo.upsert_fill({
                 "order_id": order_id,
                 "fill_id": f"paper-fill-{uuid.uuid4()}",
                 "symbol": symbol,
@@ -128,5 +234,8 @@ class PaperBroker(Broker):
                 "price": avg_price,
                 "executed_at": datetime.now(timezone.utc).isoformat()
             })
-            
+
         return order
+
+    async def close(self) -> None:
+        pass

--- a/zoe-terminal/src/components/EquityChart.tsx
+++ b/zoe-terminal/src/components/EquityChart.tsx
@@ -47,21 +47,22 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
   const [view, setView] = useState<ChartView>('alltime');
   const hasData = data.length > 1;
 
-  // Filter data based on view
+  // Filter data based on view, strip non-finite equity values
   const filteredData = useMemo(() => {
-    if (!hasData) return [];
+    const clean = data.filter(p => isFinite(p.equity) && !isNaN(p.equity));
+    if (clean.length < 2) return [];
     if (view === 'today') {
       const today = new Date().toISOString().slice(0, 10);
-      const todayData = data.filter(p => p.date.startsWith(today));
-      return todayData.length > 0 ? todayData : data.slice(-1);
+      const todayData = clean.filter(p => p.date.startsWith(today));
+      return todayData.length > 0 ? todayData : clean.slice(-1);
     }
     if (view === '7d') {
       const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-      const weekData = data.filter(p => p.date >= cutoff);
-      return weekData.length > 0 ? weekData : data.slice(-1);
+      const weekData = clean.filter(p => p.date >= cutoff);
+      return weekData.length > 0 ? weekData : clean.slice(-1);
     }
-    return data;
-  }, [data, hasData, view]);
+    return clean;
+  }, [data, view]);
 
   const isProfit = view === 'today' ? dailyPnl >= 0 : allTimePnl >= 0;
   const color = isProfit ? "#2ee59d" : "#ff5b6e";
@@ -77,8 +78,10 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
     }));
   }, [filteredData]);
 
-  const displayPnl = view === 'today' ? dailyPnl : allTimePnl;
-  const displayPct = view === 'today' ? 0 : allTimePnlPct;
+  const rawDisplayPnl = view === 'today' ? dailyPnl : allTimePnl;
+  const rawDisplayPct = view === 'today' ? 0 : allTimePnlPct;
+  const displayPnl = isFinite(rawDisplayPnl) ? rawDisplayPnl : 0;
+  const displayPct = isFinite(rawDisplayPct) ? rawDisplayPct : 0;
 
   // Determine how many ticks to show based on data density
   const tickCount = useMemo(() => {
@@ -143,9 +146,9 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
           style={{ height }}
         >
           <div className="text-center">
-            <p className="text-text-muted text-xs font-bold">No equity data yet</p>
+            <p className="text-text-muted text-xs font-bold">Not enough history yet</p>
             <p className="text-text-muted/60 text-[10px] mt-1">
-              Data will appear once cash snapshots are recorded
+              P&L curve will appear after a few snapshots are recorded
             </p>
           </div>
         </div>

--- a/zoe-terminal/src/hooks/useDashboardData.ts
+++ b/zoe-terminal/src/hooks/useDashboardData.ts
@@ -316,6 +316,19 @@ export function useDashboardData(discordId: string = "292890243852664855") {
     return 0;
   }, [cashHistory, pnlDaily]);
 
+  // BTC price from live scans (for BTC sublabel on Total card)
+  const btcPrice = useMemo(() => {
+    const btcScan = livePrices.find(s => s.symbol === 'BTC-USD');
+    if (btcScan) {
+      const mid = (btcScan.info as any)?.mid;
+      if (mid && isFinite(mid) && mid > 0) return mid;
+    }
+    return 0;
+  }, [livePrices]);
+
+  // Flag: not enough equity history to draw a meaningful chart
+  const noHistoryYet = equityHistory.length < 2;
+
   return {
     accountOverview,
     recentEvents,
@@ -332,6 +345,8 @@ export function useDashboardData(discordId: string = "292890243852664855") {
     equityHistory,
     initialDeposit,
     livePrices,
+    btcPrice,
+    noHistoryYet,
     loading,
     error,
   };

--- a/zoe-terminal/src/lib/utils.ts
+++ b/zoe-terminal/src/lib/utils.ts
@@ -28,3 +28,28 @@ export function formatDate(dateStr: string): string {
     minute: '2-digit'
   });
 }
+
+export function formatBTC(value: number): string {
+  if (!isFinite(value) || value === 0) return '0.00000000 BTC';
+  return `${value.toFixed(8)} BTC`;
+}
+
+export function formatAge(isoStringOrEpoch: string | number): string {
+  let ts: number;
+  if (typeof isoStringOrEpoch === 'number') {
+    // Kraken uses Unix epoch (seconds)
+    ts = isoStringOrEpoch < 1e12 ? isoStringOrEpoch * 1000 : isoStringOrEpoch;
+  } else {
+    ts = new Date(isoStringOrEpoch).getTime();
+  }
+  if (isNaN(ts)) return '—';
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainMin = minutes % 60;
+  if (hours < 24) return remainMin > 0 ? `${hours}h ${remainMin}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}


### PR DESCRIPTION
## Summary
- **New `integrations/kraken_client` package** — Full Kraken REST API client (HMAC-SHA512 auth, rate limiter, retry), USD converter with cascading price resolution (direct USD → USDT bridge → BTC bridge), and WebSocket v2 client for live ticker/execution/balance streams
- **Backend broker swap** — `KrakenBroker` implements the `Broker` ABC; broker factory in `__main__.py` selects exchange via `CRYPTO_EXCHANGE` env var; `trader.py` refactored to use the broker abstraction instead of the Robinhood client directly
- **Frontend dashboard overhaul** — Removed Buying Power card; 2 KPI cards (Total Account Value w/ BTC sublabel, All-Time P&L); PositionsTable gets % of Portfolio column; OpenOrdersTable gets Price, Remaining, Age columns with Kraken status mapping; comprehensive NaN guards across EquityChart, useDashboardData, and Overview

## Test plan
- [ ] Set `CRYPTO_EXCHANGE=kraken` + `KRAKEN_API_KEY` / `KRAKEN_API_SECRET` in `.env`
- [ ] Run `python -m services.crypto_trader` — verify it boots, fetches Kraken balances, writes snapshots to Supabase
- [ ] Open `zoe-terminal` dev server — verify Total Account Value (USD + BTC sublabel), All-Time P&L (no NaN), Open Positions with % of Portfolio, Active Orders with Age column
- [ ] Verify empty account shows `$0.00` and "Not enough history yet" instead of NaN
- [ ] Verify WebSocket connection (if `KRAKEN_USE_WEBSOCKET=true`) provides live price updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)