### PR TITLE
feat: dashboard polish — NaN guards, BTC sublabel, orders table, portfolio %

### DIFF
--- a/integrations/kraken_client/__init__.py
+++ b/integrations/kraken_client/__init__.py
@@ -1,5 +1,6 @@
 from .client import KrakenClient
 from .config import KrakenConfig
 from .symbols import to_kraken, from_kraken
+from .usd_converter import USDConverter
 
-__all__ = ["KrakenClient", "KrakenConfig", "to_kraken", "from_kraken"]
+__all__ = ["KrakenClient", "KrakenConfig", "USDConverter", "to_kraken", "from_kraken"]

--- a/integrations/kraken_client/usd_converter.py
+++ b/integrations/kraken_client/usd_converter.py
@@ -1,0 +1,177 @@
+"""Convert any Kraken asset balance to USD.
+
+Uses a cascading price resolution strategy:
+  1. Asset is USD → value = amount (1:1)
+  2. Direct {ASSET}-USD pair exists → use mid-price
+  3. {ASSET}-USDT pair exists → convert via USDT→USD rate
+  4. {ASSET}-BTC pair exists → convert via BTC→USD rate
+  5. Stablecoin (USDT, USDC, DAI) → assume 1:1
+  6. Fallback → $0.00 + log warning (never NaN)
+
+Caches ticker prices for 30 seconds to avoid hammering the API.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .client import KrakenClient
+
+logger = logging.getLogger(__name__)
+
+# Common assets and their direct USD pair names on Kraken
+_DIRECT_USD_PAIRS: dict[str, str] = {
+    "BTC": "BTC-USD",
+    "ETH": "ETH-USD",
+    "SOL": "SOL-USD",
+    "DOGE": "DOGE-USD",
+    "ADA": "ADA-USD",
+    "DOT": "DOT-USD",
+    "AVAX": "AVAX-USD",
+    "LINK": "LINK-USD",
+    "MATIC": "MATIC-USD",
+    "ATOM": "ATOM-USD",
+    "UNI": "UNI-USD",
+    "LTC": "LTC-USD",
+    "XRP": "XRP-USD",
+    "SHIB": "SHIB-USD",
+    "NEAR": "NEAR-USD",
+    "FIL": "FIL-USD",
+    "APT": "APT-USD",
+    "ARB": "ARB-USD",
+    "OP": "OP-USD",
+    "TRX": "TRX-USD",
+    "PEPE": "PEPE-USD",
+    "AAVE": "AAVE-USD",
+    "MKR": "MKR-USD",
+    "CRV": "CRV-USD",
+    "ALGO": "ALGO-USD",
+}
+
+_STABLECOINS = {"USDT", "USDC", "DAI", "BUSD", "TUSD", "USDP"}
+
+CACHE_TTL = 30  # seconds
+
+
+@dataclass
+class AssetValue:
+    """Result of converting an asset balance to USD."""
+    asset: str
+    amount: float
+    price_usd: float
+    value_usd: float
+
+
+class USDConverter:
+    """Converts Kraken asset balances to USD values."""
+
+    def __init__(self, client: "KrakenClient"):
+        self.client = client
+        self._cache: dict[str, float] = {}
+        self._cache_ts: float = 0
+
+    async def _refresh_cache(self) -> None:
+        """Refresh the ticker price cache if stale."""
+        if time.monotonic() - self._cache_ts < CACHE_TTL and self._cache:
+            return
+
+        try:
+            # Fetch BTC-USD price first (needed for bridge conversions)
+            btc_data = await self.client.get_best_bid_ask("BTC-USD")
+            if btc_data:
+                mid = (btc_data.get("bid", 0) + btc_data.get("ask", 0)) / 2
+                if mid > 0:
+                    self._cache["BTC-USD"] = mid
+
+            self._cache_ts = time.monotonic()
+        except Exception as e:
+            logger.warning("Failed to refresh USD converter cache: %s", e)
+
+    async def get_usd_price(self, asset: str) -> float:
+        """Get the USD price for a single asset. Returns 0.0 if unknown."""
+        if asset in ("USD", "ZUSD"):
+            return 1.0
+        if asset in _STABLECOINS:
+            return 1.0
+
+        await self._refresh_cache()
+
+        # 1. Check direct USD pair
+        pair = _DIRECT_USD_PAIRS.get(asset, f"{asset}-USD")
+        if pair in self._cache:
+            return self._cache[pair]
+
+        # Try fetching it
+        try:
+            data = await self.client.get_best_bid_ask(pair)
+            if data:
+                mid = (data.get("bid", 0) + data.get("ask", 0)) / 2
+                if mid > 0:
+                    self._cache[pair] = mid
+                    return mid
+        except Exception:
+            pass
+
+        # 2. Try USDT bridge
+        try:
+            usdt_pair = f"{asset}-USDT"
+            data = await self.client.get_best_bid_ask(usdt_pair)
+            if data:
+                mid = (data.get("bid", 0) + data.get("ask", 0)) / 2
+                if mid > 0:
+                    self._cache[usdt_pair] = mid
+                    return mid  # USDT ≈ USD
+        except Exception:
+            pass
+
+        # 3. Try BTC bridge
+        try:
+            btc_pair = f"{asset}-BTC"
+            data = await self.client.get_best_bid_ask(btc_pair)
+            if data:
+                mid = (data.get("bid", 0) + data.get("ask", 0)) / 2
+                btc_usd = self._cache.get("BTC-USD", 0)
+                if mid > 0 and btc_usd > 0:
+                    price = mid * btc_usd
+                    self._cache[f"{asset}-USD"] = price
+                    return price
+        except Exception:
+            pass
+
+        logger.warning("Could not determine USD price for %s — returning $0", asset)
+        return 0.0
+
+    async def convert_all(self, balances: dict[str, float]) -> list[AssetValue]:
+        """Convert all asset balances to USD values.
+
+        Args:
+            balances: {asset_name: amount} e.g. {"BTC": 0.5, "ETH": 2.0, "USD": 100.0}
+
+        Returns:
+            List of AssetValue with USD prices and values.
+        """
+        results: list[AssetValue] = []
+        for asset, amount in balances.items():
+            if amount <= 0:
+                continue
+            price = await self.get_usd_price(asset)
+            results.append(AssetValue(
+                asset=asset,
+                amount=amount,
+                price_usd=price,
+                value_usd=amount * price,
+            ))
+        return results
+
+    async def total_usd(self, balances: dict[str, float]) -> float:
+        """Get total USD value of all balances."""
+        values = await self.convert_all(balances)
+        return sum(v.value_usd for v in values)
+
+    async def btc_price(self) -> float:
+        """Get current BTC-USD price."""
+        await self._refresh_cache()
+        return self._cache.get("BTC-USD", 0.0)

--- a/zoe-terminal/src/components/EquityChart.tsx
+++ b/zoe-terminal/src/components/EquityChart.tsx
@@ -47,21 +47,22 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
   const [view, setView] = useState<ChartView>('alltime');
   const hasData = data.length > 1;
 
-  // Filter data based on view
+  // Filter data based on view, strip non-finite equity values
   const filteredData = useMemo(() => {
-    if (!hasData) return [];
+    const clean = data.filter(p => isFinite(p.equity) && !isNaN(p.equity));
+    if (clean.length < 2) return [];
     if (view === 'today') {
       const today = new Date().toISOString().slice(0, 10);
-      const todayData = data.filter(p => p.date.startsWith(today));
-      return todayData.length > 0 ? todayData : data.slice(-1);
+      const todayData = clean.filter(p => p.date.startsWith(today));
+      return todayData.length > 0 ? todayData : clean.slice(-1);
     }
     if (view === '7d') {
       const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-      const weekData = data.filter(p => p.date >= cutoff);
-      return weekData.length > 0 ? weekData : data.slice(-1);
+      const weekData = clean.filter(p => p.date >= cutoff);
+      return weekData.length > 0 ? weekData : clean.slice(-1);
     }
-    return data;
-  }, [data, hasData, view]);
+    return clean;
+  }, [data, view]);
 
   const isProfit = view === 'today' ? dailyPnl >= 0 : allTimePnl >= 0;
   const color = isProfit ? "#2ee59d" : "#ff5b6e";
@@ -77,8 +78,10 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
     }));
   }, [filteredData]);
 
-  const displayPnl = view === 'today' ? dailyPnl : allTimePnl;
-  const displayPct = view === 'today' ? 0 : allTimePnlPct;
+  const rawDisplayPnl = view === 'today' ? dailyPnl : allTimePnl;
+  const rawDisplayPct = view === 'today' ? 0 : allTimePnlPct;
+  const displayPnl = isFinite(rawDisplayPnl) ? rawDisplayPnl : 0;
+  const displayPct = isFinite(rawDisplayPct) ? rawDisplayPct : 0;
 
   return (
     <div className={cn("bg-surface-base border-2 border-earth-700/20 rounded-[4px] shadow-soft card-shimmer-sweep p-4 sm:p-6", className)}>
@@ -135,9 +138,9 @@ export function EquityChart({ data, dailyPnl, allTimePnl, allTimePnlPct, height 
           style={{ height }}
         >
           <div className="text-center">
-            <p className="text-text-muted text-xs font-bold">No equity data yet</p>
+            <p className="text-text-muted text-xs font-bold">Not enough history yet</p>
             <p className="text-text-muted/60 text-[10px] mt-1">
-              Data will appear once cash snapshots are recorded
+              P&L curve will appear after a few snapshots are recorded
             </p>
           </div>
         </div>

--- a/zoe-terminal/src/components/OpenOrdersTable.tsx
+++ b/zoe-terminal/src/components/OpenOrdersTable.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from 'react';
+import type { ColumnDef } from '@tanstack/react-table';
+import { DataTable } from './DataTable';
+import { formatCurrency, formatAge, cn } from '../lib/utils';
+import { useDashboardData } from '../hooks/useDashboardData';
+import { ClipboardList } from 'lucide-react';
+
+interface OrderRow {
+  symbol: string;
+  side: 'buy' | 'sell';
+  order_type: string;
+  notional: number | null;
+  qty: number | null;
+  price: number | null;
+  remaining: number | null;
+  status: string;
+  requested_at: string;
+}
+
+interface OpenOrdersTableProps {
+  hideHeader?: boolean;
+  className?: string;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  new: 'text-accent',
+  submitted: 'text-accent',
+  open: 'text-accent',
+  partially_filled: 'text-warning',
+  filled: 'text-profit',
+  closed: 'text-profit',
+  canceled: 'text-text-dim',
+  expired: 'text-text-dim',
+  rejected: 'text-loss',
+};
+
+/** Normalize Kraken order statuses to display-friendly form */
+function normalizeStatus(status: string): string {
+  switch (status) {
+    case 'open': return 'submitted';
+    case 'closed': return 'filled';
+    case 'expired': return 'canceled';
+    default: return status;
+  }
+}
+
+export function OpenOrdersTable({ hideHeader, className }: OpenOrdersTableProps) {
+  const { cryptoOrders } = useDashboardData();
+
+  // Show only open/pending orders (not yet terminal)
+  const openOrders = useMemo<OrderRow[]>(() => {
+    if (!cryptoOrders || cryptoOrders.length === 0) return [];
+
+    return cryptoOrders
+      .filter(o => ['new', 'submitted', 'partially_filled', 'open'].includes(o.status))
+      .map(o => ({
+        symbol: o.symbol,
+        side: o.side,
+        order_type: o.order_type,
+        notional: o.notional,
+        qty: o.qty,
+        price: (o as any).price ?? null,
+        remaining: (o as any).remaining ?? null,
+        status: normalizeStatus(o.status),
+        requested_at: o.requested_at,
+      }));
+  }, [cryptoOrders]);
+
+  // Recent completed orders (last 10) for context
+  const recentOrders = useMemo<OrderRow[]>(() => {
+    if (!cryptoOrders || cryptoOrders.length === 0) return [];
+
+    return cryptoOrders
+      .filter(o => ['filled', 'canceled', 'rejected', 'closed', 'expired'].includes(o.status))
+      .slice(0, 10)
+      .map(o => ({
+        symbol: o.symbol,
+        side: o.side,
+        order_type: o.order_type,
+        notional: o.notional,
+        qty: o.qty,
+        price: (o as any).price ?? null,
+        remaining: (o as any).remaining ?? null,
+        status: normalizeStatus(o.status),
+        requested_at: o.requested_at,
+      }));
+  }, [cryptoOrders]);
+
+  const allRows = useMemo(() => [...openOrders, ...recentOrders], [openOrders, recentOrders]);
+
+  const columns = useMemo<ColumnDef<OrderRow>[]>(() => [
+    {
+      header: 'Symbol',
+      accessorKey: 'symbol',
+      cell: info => <span className="font-semibold text-earth-700">{info.getValue() as string}</span>
+    },
+    {
+      header: 'Side',
+      accessorKey: 'side',
+      cell: info => {
+        const side = info.getValue() as string;
+        return (
+          <span className={cn(
+            'font-bold uppercase text-[10px] tracking-wider px-1.5 py-0.5 rounded-[4px]',
+            side === 'buy' ? 'text-profit bg-profit/10' : 'text-loss bg-loss/10'
+          )}>
+            {side}
+          </span>
+        );
+      }
+    },
+    {
+      header: 'Type',
+      accessorKey: 'order_type',
+      cell: info => (
+        <span className="text-text-secondary uppercase text-[10px] tracking-wider">
+          {info.getValue() as string}
+        </span>
+      )
+    },
+    {
+      header: 'Price',
+      accessorKey: 'price',
+      cell: info => {
+        const val = info.getValue() as number | null;
+        return val && val > 0
+          ? <span className="tabular-nums">{formatCurrency(val)}</span>
+          : <span className="text-text-dim">market</span>;
+      }
+    },
+    {
+      header: 'Amount',
+      accessorKey: 'notional',
+      cell: info => {
+        const notional = info.getValue() as number | null;
+        const row = info.row.original;
+        if (notional) return <span className="tabular-nums">{formatCurrency(notional)}</span>;
+        if (row.qty) return <span className="tabular-nums text-text-secondary">{row.qty.toFixed(6)} qty</span>;
+        return <span className="text-text-dim">&mdash;</span>;
+      }
+    },
+    {
+      header: 'Remaining',
+      accessorKey: 'remaining',
+      cell: info => {
+        const val = info.getValue() as number | null;
+        return val != null && val > 0
+          ? <span className="tabular-nums text-text-secondary">{val.toFixed(6)}</span>
+          : <span className="text-text-dim">&mdash;</span>;
+      }
+    },
+    {
+      header: 'Status',
+      accessorKey: 'status',
+      cell: info => {
+        const status = info.getValue() as string;
+        const display = status.replace(/_/g, ' ');
+        return (
+          <span className={cn(
+            'font-semibold uppercase text-[10px] tracking-wider',
+            STATUS_COLORS[status] || 'text-text-dim'
+          )}>
+            {status === 'new' || status === 'submitted' ? '\u25CF ' : ''}{display}
+          </span>
+        );
+      }
+    },
+    {
+      header: 'Age',
+      accessorKey: 'requested_at',
+      cell: info => (
+        <span className="text-text-dim text-[10px] tabular-nums">
+          {formatAge(info.getValue() as string)}
+        </span>
+      )
+    },
+  ], []);
+
+  return (
+    <div className={className}>
+      {!hideHeader && (
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted flex items-center gap-2">
+            <ClipboardList className="w-3 h-3 text-sakura-700" /> Orders
+          </h3>
+          <span className="text-[9px] font-bold text-text-dim uppercase tracking-widest">
+            {openOrders.length > 0
+              ? `${openOrders.length} open`
+              : `${recentOrders.length} recent`
+            }
+          </span>
+        </div>
+      )}
+
+      {allRows.length > 0 ? (
+        <DataTable
+          columns={columns}
+          data={allRows}
+          emptyMessage="No orders"
+        />
+      ) : (
+        <div className="bg-paper-100/80 border-2 border-earth-700/10 rounded-[4px] p-8 text-center">
+          <p className="text-text-dim text-xs">No orders yet</p>
+          <p className="text-text-dim/60 text-[9px] mt-1">Orders will appear when the bot submits trades</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/zoe-terminal/src/hooks/useDashboardData.ts
+++ b/zoe-terminal/src/hooks/useDashboardData.ts
@@ -371,6 +371,19 @@ export function useDashboardData(discordId: string = "292890243852664855") {
     return 0;
   }, [cashHistory, pnlDaily]);
 
+  // BTC price from live scans (for BTC sublabel on Total card)
+  const btcPrice = useMemo(() => {
+    const btcScan = livePrices.find(s => s.symbol === 'BTC-USD');
+    if (btcScan) {
+      const mid = (btcScan.info as any)?.mid;
+      if (mid && isFinite(mid) && mid > 0) return mid;
+    }
+    return 0;
+  }, [livePrices]);
+
+  // Flag: not enough equity history to draw a meaningful chart
+  const noHistoryYet = equityHistory.length < 2;
+
   return {
     accountOverview,
     recentEvents,
@@ -390,6 +403,8 @@ export function useDashboardData(discordId: string = "292890243852664855") {
     equityHistory,
     initialDeposit,
     livePrices,
+    btcPrice,
+    noHistoryYet,
     loading,
     error,
   };

--- a/zoe-terminal/src/lib/utils.ts
+++ b/zoe-terminal/src/lib/utils.ts
@@ -28,3 +28,31 @@ export function formatDate(dateStr: string): string {
     minute: '2-digit'
   });
 }
+
+/** Format a number as BTC with 8 decimal places (e.g., "0.00123456 BTC") */
+export function formatBTC(value: number): string {
+  if (!isFinite(value) || value === 0) return "0.00000000 BTC";
+  return `${value.toFixed(8)} BTC`;
+}
+
+/** Format an ISO date string or Unix epoch as a human-readable age (e.g., "2h 15m", "3d") */
+export function formatAge(isoStringOrEpoch: string | number): string {
+  let ms: number;
+  if (typeof isoStringOrEpoch === "number") {
+    // Accept seconds (Kraken) or milliseconds
+    const epoch = isoStringOrEpoch > 1e12 ? isoStringOrEpoch : isoStringOrEpoch * 1000;
+    ms = Date.now() - epoch;
+  } else {
+    ms = Date.now() - new Date(isoStringOrEpoch).getTime();
+  }
+  if (!isFinite(ms) || ms < 0) return "—";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  if (hr < 24) return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
+  const days = Math.floor(hr / 24);
+  return `${days}d`;
+}


### PR DESCRIPTION
## Summary
- **New `OpenOrdersTable` component** — Shows open + recent orders with Price, Remaining, Age columns and Kraken status normalization (open→submitted, closed→filled, expired→canceled)
- **PositionsTable improvements** — Added "% of Portfolio" column, renamed "Current Mark" → "Price (USD)" / "Market Value" → "Value (USD)", graceful `—` display when avg_price is missing (no fill history)
- **NaN/Infinity guards everywhere** — EquityChart strips non-finite equity values before rendering, Overview wraps allTimePnlPct and dailyPnl with `isFinite()`, empty chart shows "Not enough history yet"
- **BTC sublabel on Total card** — Shows BTC equivalent of portfolio value (e.g., "0.00123456 BTC") when BTC price available
- **USDConverter for kraken_client** — Cascading price resolution (direct USD pair → USDT bridge → BTC bridge → stablecoin fallback) with 30s cache, never returns NaN
- **New utility functions** — `formatBTC()` (8 decimal places) and `formatAge()` (human-readable "2h 15m", "3d")

## Test plan
- [ ] Open dashboard — verify Total KPI card shows BTC sublabel when BTC price is available
- [ ] Verify P&L values render as `$0.00` (not NaN) when no history exists
- [ ] Check PositionsTable shows "% of Portfolio" column and `—` for missing avg_price
- [ ] Verify OpenOrdersTable renders open + recent orders with Age column
- [ ] Confirm EquityChart shows "Not enough history yet" with < 2 data points
- [ ] TypeScript builds clean (`npx tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)